### PR TITLE
chore(deps): remove redundant Pygments pin from requirements.txt (closes #17)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ Jinja2==3.1.6
 MarkupSafe==3.0.3
 packaging==26.0
 pluggy==1.6.0
-Pygments==2.19.2
 pytest==9.0.2
 tomli==2.4.0
 typing_extensions==4.15.0


### PR DESCRIPTION
## Problem

`requirements.txt` line 12 pinned `Pygments==2.19.2`. **Application source has zero `pygments` references** — verified via `grep -rin pygments` across all .py / .html / .js / .css. The line is residue from a stale `pip freeze` snapshot.

## Change

Drop the explicit pin.

**Notable nuance worth flagging for the reviewer:** pytest 9.x lists pygments as a transitive `Requires:` (different from 8.x where it was optional / extras-only). So a fresh `pip install -r requirements.txt` *will* still install pygments — via pytest's dep tree, not ours. This is a "drop a redundant explicit version pin" change, not a "remove an installed package" change. The benefit is that future pytest bumps which need a different pygments range no longer fight an unrelated explicit pin in this file.

## Test plan

Built a clean venv from this requirements.txt and verified end-to-end:

| Check | Result |
|-------|--------|
| `pip install -r requirements.txt` succeeds | ✅ |
| pygments still installed transitively (via pytest) | ✅ — version 2.20.0 |
| `pytest tests/` | ✅ **75 / 75 OK** |
| `python app.py` + `curl /` | ✅ HTTP 200 on http://127.0.0.1:5000/ |
| Static `grep` finds zero `pygments` references in app source | ✅ |

Closes #17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused dependency from project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->