### PR TITLE
fix: pin CDN scripts + theme CSS with SRI integrity hashes (closes #19)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -5,9 +5,24 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Claude Code Chat Browser</title>
   <link rel="stylesheet" href="/static/css/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css" id="hljs-theme">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.1/marked.min.js"></script>
+  <!-- SRI hashes pin each CDN asset to a specific known-good payload; the
+       browser refuses anything whose hash does not match (issue #19).
+       crossorigin="anonymous" is required for the browser to enforce SRI
+       on cross-origin requests. Hashes verified against cdnjs's SRI API:
+         curl https://api.cdnjs.com/libraries/<name>/<version>?fields=sri
+       NOTE: the runtime theme swap in static/js/app.js MUST also swap the
+       integrity attribute when it changes href — see HLJS_THEME_SHEETS. -->
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css"
+        integrity="sha512-mtXspRdOWHCYp+f4c7CkWGYPPRAhq9X+xCvJMUBVAb6pqA4U8pxhT3RWT3LP3bKbiolYL2CkL1bSKZZO4eeTew=="
+        crossorigin="anonymous"
+        id="hljs-theme">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+          integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ=="
+          crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.1/marked.min.js"
+          integrity="sha512-pSeTnZAQF/RHxb0ysMoYQI/BRZsa5XuklcrgFfU3YZIdnD3LvkkqzrIeHxzFi6gKtI8Cpq2DEWdZjMTcNVhUYA=="
+          crossorigin="anonymous"></script>
 </head>
 <body>
   <!-- Navbar -->

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,33 @@
 // Claude Code Chat Browser — Main JS
 
+// Highlight.js theme stylesheets, keyed by theme name. Both `href` and
+// `integrity` MUST be assigned together when swapping at runtime —
+// changing `href` while leaving a stale `integrity` would make the
+// browser refuse the new stylesheet and break the UI (issue #19).
+// Hashes verified against cdnjs's SRI API. The corresponding static
+// tag in static/index.html carries crossorigin="anonymous" which
+// persists across runtime href swaps.
+const HLJS_THEME_SHEETS = {
+    dark:  {
+        href:      'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css',
+        integrity: 'sha512-mtXspRdOWHCYp+f4c7CkWGYPPRAhq9X+xCvJMUBVAb6pqA4U8pxhT3RWT3LP3bKbiolYL2CkL1bSKZZO4eeTew==',
+    },
+    light: {
+        href:      'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css',
+        integrity: 'sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA==',
+    },
+};
+
+function applyHljsTheme(themeName) {
+    const link = document.getElementById('hljs-theme');
+    if (!link) return;
+    const sheet = HLJS_THEME_SHEETS[themeName] || HLJS_THEME_SHEETS.dark;
+    // Set integrity FIRST, then href — the browser reads the current
+    // integrity at fetch time, and href change is what triggers the fetch.
+    link.integrity = sheet.integrity;
+    link.href = sheet.href;
+}
+
 function showToast(message, type = 'info') {
     const icons = { success: '\u2713', error: '\u2717', info: '\u2139' };
     const toast = document.createElement('div');
@@ -122,14 +150,8 @@ function setHamburgerVisible(visible) {
 function setWorkspaceMode(active) {
     // No container class change needed — workspace lives inside the standard container
     document.body.classList.toggle('workspace-mode', active);
-    // Switch highlight.js theme
-    const hljsLink = document.getElementById('hljs-theme');
-    if (hljsLink) {
-        const theme = localStorage.getItem('theme') || 'dark';
-        hljsLink.href = theme === 'dark'
-            ? 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css'
-            : 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css';
-    }
+    // Switch highlight.js theme — helper updates href + integrity together (issue #19).
+    applyHljsTheme(localStorage.getItem('theme') || 'dark');
 }
 
 let _navInProgress = false;
@@ -836,12 +858,7 @@ function applyTheme(theme) {
         moon.style.display = theme === 'dark' ? 'block' : 'none';
         sun.style.display = theme === 'light' ? 'block' : 'none';
     }
-    const hljsLink = document.getElementById('hljs-theme');
-    if (hljsLink) {
-        hljsLink.href = theme === 'dark'
-            ? 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/vs2015.min.css'
-            : 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css';
-    }
+    applyHljsTheme(theme);  // href + integrity swapped together (issue #19)
 }
 
 function toggleTheme() {

--- a/tests/test_hljs_theme_consistency.py
+++ b/tests/test_hljs_theme_consistency.py
@@ -1,0 +1,65 @@
+"""Regression test for highlight.js theme URL+hash drift between
+static/index.html (initial load) and static/js/app.js (runtime swap).
+
+Both files carry the dark-theme stylesheet URL and its SRI hash. On a
+highlight.js version bump both must update together — if they drift, either
+the initial load breaks (HTML stale, mismatched hash) or the runtime theme
+swap breaks (JS stale). This test fails fast when they diverge so the
+"MUST also swap the integrity attribute" comments in both files become a
+checked invariant rather than a hope.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_HTML = REPO_ROOT / "static" / "index.html"
+APP_JS = REPO_ROOT / "static" / "js" / "app.js"
+
+
+def _link_attr(html: str, link_id: str, attr: str) -> str:
+    """Return the value of `attr` on the <link> tag with id=`link_id`."""
+    tag_re = re.compile(
+        r'<link\b[^>]*\bid\s*=\s*"' + re.escape(link_id) + r'"[^>]*>',
+        re.DOTALL,
+    )
+    m = tag_re.search(html)
+    assert m, f'No <link id="{link_id}"> found in index.html'
+    attr_m = re.search(re.escape(attr) + r'\s*=\s*"([^"]*)"', m.group(0))
+    assert attr_m, f'<link id="{link_id}"> has no {attr!r} attribute'
+    return attr_m.group(1)
+
+
+def _js_theme_entry(js: str, theme: str) -> dict:
+    """Return {'href': ..., 'integrity': ...} from HLJS_THEME_SHEETS.<theme>."""
+    block = re.search(re.escape(theme) + r"\s*:\s*\{([^}]*)\}", js, re.DOTALL)
+    assert block, f"HLJS_THEME_SHEETS.{theme} entry not found in app.js"
+    body = block.group(1)
+    out = {}
+    for key in ("href", "integrity"):
+        m = re.search(key + r"\s*:\s*['\"]([^'\"]+)['\"]", body)
+        assert m, f"HLJS_THEME_SHEETS.{theme} has no {key!r} key"
+        out[key] = m.group(1)
+    return out
+
+
+def test_dark_theme_url_and_hash_match_between_html_and_js():
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    js = APP_JS.read_text(encoding="utf-8")
+
+    html_href = _link_attr(html, "hljs-theme", "href")
+    html_integrity = _link_attr(html, "hljs-theme", "integrity")
+    js_dark = _js_theme_entry(js, "dark")
+
+    assert html_href == js_dark["href"], (
+        "highlight.js theme URL drifted between index.html and app.js — "
+        f"html={html_href!r}, app.js HLJS_THEME_SHEETS.dark={js_dark['href']!r}. "
+        "On a version bump both must update together (issue #19)."
+    )
+    assert html_integrity == js_dark["integrity"], (
+        "highlight.js theme SRI hash drifted between index.html and app.js — "
+        f"html={html_integrity!r}, "
+        f"app.js HLJS_THEME_SHEETS.dark={js_dark['integrity']!r}."
+    )


### PR DESCRIPTION
## Problem

Three cross-origin assets in [`static/index.html`](static/index.html) loaded without integrity attributes — the dashboard executed whatever the CDN delivered. Marked.js parses raw markdown and highlight.js runs on every code block, so a swapped payload would have full DOM access in our origin.

## Change

- **`static/index.html`** — `integrity="sha512-…"` + `crossorigin="anonymous"` on all three CDN tags (highlight.js JS + CSS + marked.js).
- **`static/js/app.js`** — runtime theme swap previously rewrote `href` between `vs2015.min.css` and `github.min.css` via inline ternary. With integrity on the static tag, that would have left a stale hash at the moment of fetch and broken the UI on theme toggle. Replaced both inline sites with a const-map helper:

  ```js
  const HLJS_THEME_SHEETS = {
    dark:  { href: '…vs2015.min.css',  integrity: 'sha512-…' },
    light: { href: '…github.min.css',  integrity: 'sha512-…' },
  };

  function applyHljsTheme(theme) {
    const link = document.getElementById('hljs-theme');
    if (!link) return;
    const sheet = HLJS_THEME_SHEETS[theme] || HLJS_THEME_SHEETS.dark;
    link.integrity = sheet.integrity;  // set FIRST so the browser sees it at fetch time
    link.href = sheet.href;
  }
  ```

## Test plan

All four SHA-512 hashes verified two ways:

| Method | Source |
|--------|--------|
| `gh api 'https://api.cdnjs.com/libraries/<name>/<version>?fields=sri'` | cdnjs's published SRI for the version |
| `curl -sL <url> \| openssl dgst -sha512 -binary \| base64` | Re-derived from the actual CDN response |

Both methods agree for all four files (vs2015 / github CSS, highlight.min.js, marked.min.js).

End-to-end:

- ✅ `pytest tests/` — **75/75 OK** (no behaviour change in Python).
- ✅ Served HTML carries `integrity` + `crossorigin` on all three CDN tags.
- ✅ App boots clean, returns HTTP 200 on `http://127.0.0.1:5000/`.

Manual browser verification (DevTools → Console + Network):

1. First load — highlight.js, marked.js, vs2015.min.css all 200, no SRI error in Console.
2. Toggle theme (sun/moon icon) — `github.min.css` fetched fresh with its own hash, page recolours, no SRI error.
3. Toggle back — `vs2015.min.css` re-fetches / cached, no SRI error.

Forced negative test (optional): mutate one character of any `integrity` attr → browser refuses the resource with the distinctive `Failed to find a valid digest in the 'integrity' attribute…` console message. Confirms enforcement is real, not silently bypassed.

Closes #19.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime theme switching so code highlighting updates reliably when changing themes.

* **Security**
  * Added Subresource Integrity (SRI) and crossorigin attributes for CDN-loaded highlighting and Markdown assets to prevent tampering.

* **Tests**
  * Added a regression test ensuring highlight theme URLs and their SRI hashes remain consistent between markup and runtime theme logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->