### PR TITLE
chore(deps): drop transitives from requirements.txt, split prod from dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pytest:
+  prod-install-smoke:
+    name: Verify prod requirements.txt is sufficient
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,8 +23,37 @@ jobs:
           cache: pip
           cache-dependency-path: requirements.txt
 
-      - name: Install dependencies
+      - name: Install production dependencies only
         run: pip install -r requirements.txt
+
+      # Boots the app under test_client without pytest. Catches the case
+      # where someone adds a real third-party import (e.g. werkzeug.X)
+      # to the source without bumping requirements.txt — that would
+      # surface here as ImportError before merge.
+      - name: Import + boot app
+        run: |
+          python - <<'PY'
+          from app import create_app
+          app = create_app()
+          client = app.test_client()
+          assert client.get("/").status_code == 200
+          PY
+
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dev dependencies (Flask + pytest)
+        run: pip install -r requirements-dev.txt
 
       - name: Run tests
         run: pytest --tb=short -q

--- a/README.md
+++ b/README.md
@@ -107,9 +107,20 @@ claude-code-chat-browser/
 └── tests/
 ```
 
+## Development
+
+To run the test suite, install the dev requirements (Flask + pytest):
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+`requirements.txt` carries only the runtime dep (Flask); `requirements-dev.txt` pulls it in via `-r` and adds pytest.
+
 ## Continuous integration
 
-Every push and pull request runs **`pytest`** on **Ubuntu** (Python 3.12) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Every push and pull request runs **`pytest`** on **Ubuntu** (Python 3.12) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A separate job verifies that `pip install -r requirements.txt` (production-only) is sufficient to import and boot the app.
 
 ## Exported Markdown Format
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==9.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,1 @@
-blinker==1.9.0
-click==8.3.1
-colorama==0.4.6
-exceptiongroup==1.3.1
 Flask==3.1.3
-iniconfig==2.3.0
-itsdangerous==2.2.0
-Jinja2==3.1.6
-MarkupSafe==3.0.3
-packaging==26.0
-pluggy==1.6.0
-pytest==9.0.2
-tomli==2.4.0
-typing_extensions==4.15.0
-Werkzeug==3.1.6


### PR DESCRIPTION
## Problem

`requirements.txt` listed 15 pinned packages, but only **two** are directly imported anywhere in the source: `Flask` (production) and `pytest` (test-only). The other 13 are transitive deps that pip resolves automatically. Side effects: production users following the README's `pip install -r requirements.txt` step get a test framework they don't need, and there was no clean place to declare dev-only deps.

## Change

- `requirements.txt`: keep `Flask==3.1.3` only.
- New `requirements-dev.txt`: `-r requirements.txt` + `pytest==9.0.2`.
- `.github/workflows/ci.yml`: split into two jobs:
  - **`prod-install-smoke`** — installs `requirements.txt` only and boots the app via `test_client`. Catches future PRs that add a direct third-party import without bumping `requirements.txt`.
  - **`pytest`** — installs `requirements-dev.txt`, runs the suite. Cache key now tracks both files.
- `README.md`: new `Development` section pointing at `requirements-dev.txt` for tests.

## Test plan

- [x] `pip install -r requirements.txt` from a clean venv → 7 packages auto-resolved (Flask + 6 transitives)
- [x] `python app.py --port 5701` on prod-only venv → boots, `GET /` / `/api/projects` / `/api/search?q=x` all 200, `GET /api/sessions/x/y` 404 as expected
- [x] `scripts/export.py --help` and `scripts/export.py list` work on prod-only venv
- [x] `pip install -r requirements-dev.txt` from a clean venv → 12 packages
- [x] `pytest tests/` on dev venv → **92/92 pass**
- [x] `actionlint .github/workflows/ci.yml` → exit 0

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added production verification job in CI pipeline to validate app startup and root endpoint.
  * Separated development and production dependencies for clearer environment management.

* **Documentation**
  * Added Development section explaining how to run the test suite locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->