### PR TITLE
refactor: centralize slugify in utils (#30)

### DIFF
--- a/api/export_api.py
+++ b/api/export_api.py
@@ -14,6 +14,7 @@ from utils.session_stats import compute_stats
 from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
 from utils.exclusion_rules import is_session_excluded
+from utils.slugify import slugify
 
 export_bp = Blueprint("export", __name__)
 
@@ -47,13 +48,6 @@ def get_export_state():
         "last_export_time": state.get("lastExportTime"),
         "export_count": state.get("exportedCount", 0),
     })
-
-
-def _slugify(text: str) -> str:
-    import re
-    text = text.lower()
-    text = re.sub(r"[^a-z0-9]+", "-", text)
-    return text.strip("-")
 
 
 @export_bp.route("/api/export", methods=["POST"])
@@ -97,9 +91,9 @@ def bulk_export():
 
                     stats = compute_stats(session)
                     md = session_to_markdown(session, stats)
-                    title_slug = _slugify(session["title"]) or "session"
+                    title_slug = slugify(session["title"]) or "session"
                     short_id = sid[:8]
-                    proj_slug = _slugify(project["name"])
+                    proj_slug = slugify(project["name"])
                     ts = session["metadata"].get("first_timestamp", "")
                     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
                     rel_path = f"{proj_slug}/{ts_file}__{title_slug}__{short_id}.md"
@@ -155,7 +149,7 @@ def export_session(project_name, session_id):
     if is_session_excluded(rules, session, project_name):
         return jsonify({"error": "Session not found"}), 404
     stats = compute_stats(session)
-    title_slug = _slugify(session["title"]) or "session"
+    title_slug = slugify(session["title"]) or "session"
 
     if fmt == "json":
         content = session_to_json(session, stats)

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -91,9 +91,9 @@ def bulk_export():
 
                     stats = compute_stats(session)
                     md = session_to_markdown(session, stats)
-                    title_slug = slugify(session["title"]) or "session"
+                    title_slug = slugify(session["title"], default="session")
                     short_id = sid[:8]
-                    proj_slug = slugify(project["name"]) or "project"
+                    proj_slug = slugify(project["name"], default="project")
                     ts = session["metadata"].get("first_timestamp", "")
                     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
                     rel_path = f"{proj_slug}/{ts_file}__{title_slug}__{short_id}.md"
@@ -149,7 +149,7 @@ def export_session(project_name, session_id):
     if is_session_excluded(rules, session, project_name):
         return jsonify({"error": "Session not found"}), 404
     stats = compute_stats(session)
-    title_slug = slugify(session["title"]) or "session"
+    title_slug = slugify(session["title"], default="session")
 
     if fmt == "json":
         content = session_to_json(session, stats)

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -93,7 +93,7 @@ def bulk_export():
                     md = session_to_markdown(session, stats)
                     title_slug = slugify(session["title"]) or "session"
                     short_id = sid[:8]
-                    proj_slug = slugify(project["name"])
+                    proj_slug = slugify(project["name"]) or "project"
                     ts = session["metadata"].get("first_timestamp", "")
                     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
                     rel_path = f"{proj_slug}/{ts_file}__{title_slug}__{short_id}.md"

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -33,6 +33,7 @@ from utils.exclusion_rules import (
     load_rules,
     is_session_excluded,
 )
+from utils.slugify import slugify
 
 
 STATE_DIR = os.path.join(os.path.expanduser("~"), ".claude-code-chat-browser")
@@ -366,9 +367,9 @@ def cmd_export(args):
                 meta["first_timestamp"] = ts
             date_str = ts[:10]
             ts_file = ts[:19].replace(":", "-")   # 2026-02-10T01-46-15
-            title_slug = _slugify(session["title"])
+            title_slug = slugify(session["title"])
             short_id = sid[:8]
-            project_slug = _slugify(project["name"])
+            project_slug = slugify(project["name"])
 
             if fmt in ("md", "both"):
                 md = session_to_markdown(session, stats)
@@ -444,7 +445,7 @@ def cmd_export(args):
 
 def _export_single(session: dict, stats: dict, fmt: str, out_dir: str):
     """Write one session to disk as md, json, or both."""
-    title_slug = _slugify(session["title"])
+    title_slug = slugify(session["title"])
     short_id = session["session_id"][:8]
     ts = session["metadata"].get("first_timestamp", "")
     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
@@ -607,18 +608,6 @@ def _save_state(sessions: dict, count: int, out_dir: str):
     }
     with open(STATE_FILE, "w") as f:
         json.dump(state, f, indent=2)
-
-
-def _slugify(text: str) -> str:
-    slug = ""
-    for c in text.lower():
-        if c.isalnum():
-            slug += c
-        elif c in " -_/.":
-            slug += "-"
-    while "--" in slug:
-        slug = slug.replace("--", "-")
-    return slug.strip("-")
 
 
 def _die(msg: str):

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -367,9 +367,9 @@ def cmd_export(args):
                 meta["first_timestamp"] = ts
             date_str = ts[:10]
             ts_file = ts[:19].replace(":", "-")   # 2026-02-10T01-46-15
+            title_slug = slugify(session["title"], default="session")
             short_id = sid[:8]
-            title_slug = slugify(session["title"]) or "session"
-            project_slug = slugify(project["name"]) or "project"
+            project_slug = slugify(project["name"], default="project")
 
             if fmt in ("md", "both"):
                 md = session_to_markdown(session, stats)
@@ -445,8 +445,8 @@ def cmd_export(args):
 
 def _export_single(session: dict, stats: dict, fmt: str, out_dir: str):
     """Write one session to disk as md, json, or both."""
+    title_slug = slugify(session["title"], default="session")
     short_id = session["session_id"][:8]
-    title_slug = slugify(session["title"]) or "session"
     ts = session["metadata"].get("first_timestamp", "")
     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
 

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -367,9 +367,9 @@ def cmd_export(args):
                 meta["first_timestamp"] = ts
             date_str = ts[:10]
             ts_file = ts[:19].replace(":", "-")   # 2026-02-10T01-46-15
-            title_slug = slugify(session["title"])
             short_id = sid[:8]
-            project_slug = slugify(project["name"])
+            title_slug = slugify(session["title"]) or "session"
+            project_slug = slugify(project["name"]) or "project"
 
             if fmt in ("md", "both"):
                 md = session_to_markdown(session, stats)
@@ -445,8 +445,8 @@ def cmd_export(args):
 
 def _export_single(session: dict, stats: dict, fmt: str, out_dir: str):
     """Write one session to disk as md, json, or both."""
-    title_slug = slugify(session["title"])
     short_id = session["session_id"][:8]
+    title_slug = slugify(session["title"]) or "session"
     ts = session["metadata"].get("first_timestamp", "")
     ts_file = ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
 

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -5,6 +5,8 @@ while ``api/export_api.py`` used ASCII-only ``[^a-z0-9]+``. The canonical
 implementation matches the API for portable zip / download filenames.
 """
 
+import os
+
 from utils.slugify import slugify
 
 
@@ -28,3 +30,31 @@ def test_empty_after_strip():
 
 def test_digits_preserved():
     assert slugify("Issue 42 Fix") == "issue-42-fix"
+
+
+def test_punctuation_examples_match_regex_behavior():
+    assert slugify("AT&T") == "at-t"
+    assert slugify("issue#42") == "issue-42"
+
+
+def test_default_used_when_slug_empty():
+    assert slugify("!!!", default="session") == "session"
+    assert slugify("!!!") == ""
+
+
+def test_export_leaf_path_parity_api_zip_vs_cli():
+    """Same session inputs → same ``proj_slug``, ``title_slug``, and file leaf as API vs CLI."""
+    title = "Issue #42: AT&T"
+    project = "Foo/Bar!"
+    sid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    ts_file = "2026-05-07T12-00-00"
+    short_id = sid[:8]
+    title_slug = slugify(title, default="session")
+    proj_slug = slugify(project, default="project")
+    leaf_md = f"{ts_file}__{title_slug}__{short_id}.md"
+    api_zip_inner = f"{proj_slug}/{leaf_md}"
+    date_str = ts_file[:10]
+    cli_rel = os.path.join(date_str, proj_slug, leaf_md)
+    assert api_zip_inner.endswith(leaf_md)
+    assert os.path.basename(cli_rel) == leaf_md
+    assert cli_rel.replace("\\", "/").endswith(f"{proj_slug}/{leaf_md}")

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,0 +1,30 @@
+"""Regression tests for utils.slugify (Issue #30 / CCC8).
+
+Historically ``scripts/export.py`` used ``isalnum()`` (Unicode letters preserved)
+while ``api/export_api.py`` used ASCII-only ``[^a-z0-9]+``. The canonical
+implementation matches the API for portable zip / download filenames.
+"""
+
+from utils.slugify import slugify
+
+
+def test_ascii_words_hyphenated():
+    assert slugify("Hello World") == "hello-world"
+
+
+def test_punctuation_collapses_to_single_hyphen():
+    assert slugify("foo__bar") == "foo-bar"
+    assert slugify("a.b.c") == "a-b-c"
+
+
+def test_unicode_letters_become_ascii_safe():
+    """Old CLI kept Latin-1 letters (e.g. é); canonical slug strips to ASCII."""
+    assert slugify("Café noir") == "caf-noir"
+
+
+def test_empty_after_strip():
+    assert slugify("!!!") == ""
+
+
+def test_digits_preserved():
+    assert slugify("Issue 42 Fix") == "issue-42-fix"

--- a/utils/slugify.py
+++ b/utils/slugify.py
@@ -1,0 +1,18 @@
+"""Filesystem- and URL-safe slugs for export paths and download names.
+
+Uses ASCII letters and digits only; other characters (including Unicode
+letters and punctuation) become hyphen runs, then trimmed. Matches the
+historical behavior of ``api/export_api.py`` and avoids platform-specific
+issues with non-ASCII paths inside zip archives.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def slugify(text: str) -> str:
+    """Lowercase *text* and replace each run of non-[a-z0-9] with a single hyphen."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")

--- a/utils/slugify.py
+++ b/utils/slugify.py
@@ -6,8 +6,6 @@ historical behavior of ``api/export_api.py`` and avoids platform-specific
 issues with non-ASCII paths inside zip archives.
 """
 
-from __future__ import annotations
-
 import re
 
 

--- a/utils/slugify.py
+++ b/utils/slugify.py
@@ -11,8 +11,19 @@ from __future__ import annotations
 import re
 
 
-def slugify(text: str) -> str:
-    """Lowercase *text* and replace each run of non-[a-z0-9] with a single hyphen."""
+def slugify(text: str, *, default: str = "") -> str:
+    """Lowercase *text* and replace each run of non-[a-z0-9] with one hyphen.
+
+    After stripping leading/trailing hyphens, returns that string; if it is
+    empty, returns *default*. Export code passes ``default="session"`` or
+    ``default="project"``.
+    Examples (handled by the ``[^a-z0-9]+`` substitution below):
+
+    - ``AT&T`` → ``at-t``
+    - ``issue#42`` → ``issue-42``
+    """
     text = text.lower()
+    # Non-ASCII-alphanumeric runs → '-'; e.g. AT&T → at-t, issue#42 → issue-42.
     text = re.sub(r"[^a-z0-9]+", "-", text)
-    return text.strip("-")
+    stripped = text.strip("-")
+    return stripped if stripped else default


### PR DESCRIPTION
## Summary

Consolidates **`_slugify`** into a single implementation under **`utils.slugify.slugify`**, completing the residual **CCC8** work after **PR #24** (session-text exclusion plumbing). **`api/export_api.py`** and **`scripts/export.py`** now both import the shared helper; duplicate local definitions are removed.

## Changes

- Add **`utils/slugify.py`** with **`slugify(text: str) -> str`**: lowercase, replace runs of non-`[a-z0-9]` with `-`, strip hyphens (matches former **`export_api`** behavior).
- **`api/export_api.py`**: drop local **`_slugify`**, use **`from utils.slugify import slugify`**.
- **`scripts/export.py`**: drop character-loop **`_slugify`** (`isalnum` / Unicode-preserving), use shared **`slugify`**.
- Add **`tests/test_slugify.py`** for ASCII, punctuation collapse, Unicode titles, empty-ish input, and digits.

## Behavior note

Canonical slugging is **ASCII-only** (same as the previous HTTP export path). CLI export filenames for titles with non-ASCII letters **may change** vs the old script (e.g. accented characters are folded into hyphens like the web bulk export). Zip and download filenames stay predictable across platforms.

## Testing

- `pytest` — **186 passed** locally.

## References

- Closes #30
- Related: #23 / PR #24 (exclusion helpers); eval **§5.2** / footnote 9 (`_slugify` divergence); **`claude-cursor.md`** **CCC8**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export API responses now include last_export_time and export_count for improved export visibility.  
* **Improvements**
  * Exported filenames and archive paths now use a consistent ASCII-safe slug format with a fallback default for empty titles, ensuring portable, predictable naming and parity between CLI and API exports.  
* **Tests**
  * Added regression tests covering slug behavior: hyphenation, punctuation collapsing, Unicode handling, empty-input fallback, and digit preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->