### PR TITLE
feat: runtime SessionDict validation at JSONL parse boundary

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 """Flask app that serves the web GUI for browsing sessions."""
 
+import argparse
 import os
 import sys
 
@@ -35,10 +36,8 @@ def create_app(
     return app
 
 
-def build_cli_parser():
+def build_cli_parser() -> argparse.ArgumentParser:
     """CLI argument parser for ``python app.py`` (stdlib only; safe to import in tests)."""
-    import argparse
-
     parser = argparse.ArgumentParser(description="Claude Code Chat Browser")
     parser.add_argument("--port", type=int, default=5000)
     parser.add_argument("--host", default="127.0.0.1")

--- a/models/errors.py
+++ b/models/errors.py
@@ -12,4 +12,5 @@ class SessionValidationError(ValueError):
 
     def __init__(self, path: str, detail: str) -> None:
         self.path = path
+        self.detail = detail
         super().__init__(f"Session validation failed at {path}: {detail}")

--- a/models/errors.py
+++ b/models/errors.py
@@ -1,7 +1,15 @@
-"""HTTP error response shapes."""
+"""HTTP error response shapes and domain validation errors."""
 
 from typing import TypedDict
 
 
 class ErrorResponse(TypedDict):
     error: str
+
+
+class SessionValidationError(ValueError):
+    """Raised when parsed JSONL output does not match SessionDict contract."""
+
+    def __init__(self, path: str, detail: str) -> None:
+        self.path = path
+        super().__init__(f"Session validation failed at {path}: {detail}")

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -1,0 +1,72 @@
+"""Runtime validation at the JSONL → SessionDict boundary."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from models.errors import SessionValidationError  # noqa: E402
+from utils.jsonl_parser import parse_session  # noqa: E402
+from utils.validation import validate_session_dict  # noqa: E402
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def _valid_payload(**overrides: object) -> dict:
+    base = {
+        "session_id": "abc123",
+        "title": "Test Session",
+        "messages": [{"role": "user", "text": "hello"}],
+        "metadata": {"session_id": "abc123"},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidateSessionDict:
+    def test_missing_session_id(self):
+        payload = _valid_payload()
+        del payload["session_id"]
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(payload)
+        assert exc_info.value.path == "session_id"
+
+    def test_wrong_type_session_id(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(_valid_payload(session_id=123))
+        assert exc_info.value.path == "session_id"
+
+    def test_null_role_in_message(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(
+                _valid_payload(messages=[{"role": None, "text": "x"}])
+            )
+        assert exc_info.value.path == "messages[0].role"
+
+    def test_metadata_not_dict(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(_valid_payload(metadata="not-a-dict"))
+        assert exc_info.value.path == "metadata"
+
+    def test_message_not_dict(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(_valid_payload(messages=["not-a-dict"]))
+        assert exc_info.value.path == "messages[0]"
+
+    def test_valid_payload_returns_session_dict(self):
+        result = validate_session_dict(_valid_payload())
+        assert result["session_id"] == "abc123"
+        assert result["messages"][0]["role"] == "user"
+
+
+class TestParseSessionValidationRegression:
+    def test_session_minimal_fixture_unchanged(self):
+        path = os.path.join(FIXTURES, "session_minimal.jsonl")
+        session = parse_session(path)
+        assert session["session_id"] == "session_minimal"
+        assert session["title"] == "Hello from integration fixture"
+        assert len(session["messages"]) == 2
+        assert session["messages"][0]["role"] == "user"
+        assert session["messages"][1]["role"] == "assistant"

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from typing import Any
 
 import pytest
 
@@ -14,8 +15,8 @@ from utils.validation import validate_session_dict  # noqa: E402
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
-def _valid_payload(**overrides: object) -> dict:
-    base = {
+def _valid_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
         "session_id": "abc123",
         "title": "Test Session",
         "messages": [{"role": "user", "text": "hello"}],

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -39,6 +39,12 @@ class TestValidateSessionDict:
             validate_session_dict(_valid_payload(session_id=123))
         assert exc_info.value.path == "session_id"
 
+    def test_null_session_id(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(_valid_payload(session_id=None))
+        assert exc_info.value.path == "session_id"
+        assert exc_info.value.detail == "must not be null"
+
     def test_null_role_in_message(self):
         with pytest.raises(SessionValidationError) as exc_info:
             validate_session_dict(

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -46,6 +46,13 @@ class TestValidateSessionDict:
             )
         assert exc_info.value.path == "messages[0].role"
 
+    def test_missing_role_in_message(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(
+                _valid_payload(messages=[{"text": "no role key"}])
+            )
+        assert exc_info.value.path == "messages[0].role"
+
     def test_metadata_not_dict(self):
         with pytest.raises(SessionValidationError) as exc_info:
             validate_session_dict(_valid_payload(metadata="not-a-dict"))

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -4,9 +4,10 @@ actually work with -- messages, tool calls, token counts, file activity, etc."""
 import json
 import os
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 from models.session import MessageDict, QuickSessionInfoDict, SessionDict
+from utils.validation import validate_session_dict
 
 
 def parse_session(filepath: str) -> SessionDict:
@@ -120,14 +121,13 @@ def parse_session(filepath: str) -> SessionDict:
 
     title = _infer_title(messages)
 
-    return cast(
-        SessionDict,
+    return validate_session_dict(
         {
             "session_id": session_id,
             "title": title,
             "messages": messages,
             "metadata": metadata,
-        },
+        }
     )
 
 

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -5,68 +5,52 @@ from typing import Any, cast
 from models.errors import SessionValidationError
 from models.session import SessionDict
 
-_REQUIRED_SESSION_KEYS = ("session_id", "title", "messages", "metadata")
+_ROOT_PATH = "(root)"
+
+
+def _require_field(
+    container: dict[str, Any],
+    key: str,
+    expected_type: type[Any],
+    type_label: str,
+    *,
+    path: str | None = None,
+) -> Any:
+    field_path = path or key
+    if key not in container:
+        raise SessionValidationError(field_path, "missing required field")
+    return _require_value(field_path, container[key], expected_type, type_label)
+
+
+def _require_value(
+    path: str,
+    val: Any,
+    expected_type: type[Any],
+    type_label: str,
+) -> Any:
+    if val is None:
+        raise SessionValidationError(path, "must not be null")
+    if not isinstance(val, expected_type):
+        raise SessionValidationError(
+            path, f"expected {type_label}, got {type(val).__name__}"
+        )
+    return val
 
 
 def validate_session_dict(data: dict[str, Any]) -> SessionDict:
     """Validate a plain dict matches SessionDict before returning it."""
     # Runtime guard for dynamic callers; mypy already types the parameter as dict.
     if not isinstance(data, dict):
-        raise SessionValidationError("$", "expected dict")
+        raise SessionValidationError(_ROOT_PATH, "expected dict")
 
-    for key in _REQUIRED_SESSION_KEYS:
-        if key not in data:
-            raise SessionValidationError(key, "missing required field")
-
-    session_id = data["session_id"]
-    # Explicit null check before isinstance so errors say "must not be null".
-    if session_id is None:
-        raise SessionValidationError("session_id", "must not be null")
-    if not isinstance(session_id, str):
-        raise SessionValidationError(
-            "session_id", f"expected str, got {type(session_id).__name__}"
-        )
-
-    title = data["title"]
-    if title is None:
-        raise SessionValidationError("title", "must not be null")
-    if not isinstance(title, str):
-        raise SessionValidationError(
-            "title", f"expected str, got {type(title).__name__}"
-        )
-
-    messages = data["messages"]
-    if messages is None:
-        raise SessionValidationError("messages", "must not be null")
-    if not isinstance(messages, list):
-        raise SessionValidationError(
-            "messages", f"expected list, got {type(messages).__name__}"
-        )
+    _require_field(data, "session_id", str, "str")
+    _require_field(data, "title", str, "str")
+    messages = _require_field(data, "messages", list, "list")
+    _require_field(data, "metadata", dict, "dict")
 
     for index, message in enumerate(messages):
         path = f"messages[{index}]"
-        if message is None:
-            raise SessionValidationError(path, "must not be null")
-        if not isinstance(message, dict):
-            raise SessionValidationError(
-                path, f"expected dict, got {type(message).__name__}"
-            )
-        if "role" not in message:
-            raise SessionValidationError(f"{path}.role", "missing required field")
-        role = message["role"]
-        if role is None:
-            raise SessionValidationError(f"{path}.role", "must not be null")
-        if not isinstance(role, str):
-            raise SessionValidationError(
-                f"{path}.role", f"expected str, got {type(role).__name__}"
-            )
-
-    metadata = data["metadata"]
-    if metadata is None:
-        raise SessionValidationError("metadata", "must not be null")
-    if not isinstance(metadata, dict):
-        raise SessionValidationError(
-            "metadata", f"expected dict, got {type(metadata).__name__}"
-        )
+        msg_dict = _require_value(path, message, dict, "dict")
+        _require_field(msg_dict, "role", str, "str", path=f"{path}.role")
 
     return cast(SessionDict, data)

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,0 +1,78 @@
+"""Runtime validation for TypedDict shapes at untrusted-data boundaries."""
+
+from typing import Any, cast
+
+from models.errors import SessionValidationError
+from models.session import MessageDict, SessionDict
+
+_REQUIRED_SESSION_KEYS = ("session_id", "title", "messages", "metadata")
+
+
+def validate_session_dict(data: dict[str, Any]) -> SessionDict:
+    """Validate a plain dict matches SessionDict before returning it."""
+    if not isinstance(data, dict):
+        raise SessionValidationError("$", "expected dict")
+
+    for key in _REQUIRED_SESSION_KEYS:
+        if key not in data:
+            raise SessionValidationError(key, "missing required field")
+
+    session_id = data["session_id"]
+    if session_id is None:
+        raise SessionValidationError("session_id", "must not be null")
+    if not isinstance(session_id, str):
+        raise SessionValidationError(
+            "session_id", f"expected str, got {type(session_id).__name__}"
+        )
+
+    title = data["title"]
+    if title is None:
+        raise SessionValidationError("title", "must not be null")
+    if not isinstance(title, str):
+        raise SessionValidationError(
+            "title", f"expected str, got {type(title).__name__}"
+        )
+
+    messages = data["messages"]
+    if messages is None:
+        raise SessionValidationError("messages", "must not be null")
+    if not isinstance(messages, list):
+        raise SessionValidationError(
+            "messages", f"expected list, got {type(messages).__name__}"
+        )
+
+    for index, message in enumerate(messages):
+        path = f"messages[{index}]"
+        if message is None:
+            raise SessionValidationError(path, "must not be null")
+        if not isinstance(message, dict):
+            raise SessionValidationError(
+                path, f"expected dict, got {type(message).__name__}"
+            )
+        if "role" not in message:
+            raise SessionValidationError(f"{path}.role", "missing required field")
+        role = message["role"]
+        if role is None:
+            raise SessionValidationError(f"{path}.role", "must not be null")
+        if not isinstance(role, str):
+            raise SessionValidationError(
+                f"{path}.role", f"expected str, got {type(role).__name__}"
+            )
+
+    metadata = data["metadata"]
+    if metadata is None:
+        raise SessionValidationError("metadata", "must not be null")
+    if not isinstance(metadata, dict):
+        raise SessionValidationError(
+            "metadata", f"expected dict, got {type(metadata).__name__}"
+        )
+
+    return cast(
+        SessionDict,
+        {
+            "session_id": session_id,
+            "title": title,
+            "messages": cast(list[MessageDict], messages),
+            "metadata": metadata,
+        },
+    )

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -3,13 +3,14 @@
 from typing import Any, cast
 
 from models.errors import SessionValidationError
-from models.session import MessageDict, SessionDict
+from models.session import SessionDict
 
 _REQUIRED_SESSION_KEYS = ("session_id", "title", "messages", "metadata")
 
 
 def validate_session_dict(data: dict[str, Any]) -> SessionDict:
     """Validate a plain dict matches SessionDict before returning it."""
+    # Runtime guard for dynamic callers; mypy already types the parameter as dict.
     if not isinstance(data, dict):
         raise SessionValidationError("$", "expected dict")
 
@@ -18,6 +19,7 @@ def validate_session_dict(data: dict[str, Any]) -> SessionDict:
             raise SessionValidationError(key, "missing required field")
 
     session_id = data["session_id"]
+    # Explicit null check before isinstance so errors say "must not be null".
     if session_id is None:
         raise SessionValidationError("session_id", "must not be null")
     if not isinstance(session_id, str):
@@ -67,12 +69,4 @@ def validate_session_dict(data: dict[str, Any]) -> SessionDict:
             "metadata", f"expected dict, got {type(metadata).__name__}"
         )
 
-    return cast(
-        SessionDict,
-        {
-            "session_id": session_id,
-            "title": title,
-            "messages": cast(list[MessageDict], messages),
-            "metadata": metadata,
-        },
-    )
+    return cast(SessionDict, data)


### PR DESCRIPTION
Closes #46 
## Summary
Adds runtime validation at the JSONL → `SessionDict` ingress boundary in `claude-code-chat-browser`. Untrusted session files are no longer passed through `cast()`; malformed assembled payloads raise a specific, catchable `SessionValidationError`.
**Depends on:** PR1 (`fix/debug-flag-default-false`) should merge first per Monday plan; this PR has no code dependency on PR1 (touches `utils/` / `models/` only).
## Changes
- **`utils/validation.py`** — `validate_session_dict()` checks required keys and types (`session_id`, `title`, `messages`, `metadata`; each message has non-null `role: str`)
- **`models/errors.py`** — `SessionValidationError(ValueError)` with `path` and formatted message
- **`utils/jsonl_parser.py`** — `parse_session()` return uses `validate_session_dict()` instead of `cast(SessionDict, ...)`
- **`tests/test_jsonl_validation.py`** — 5 malformed-input tests + happy-path regression on `tests/fixtures/session_minimal.jsonl`
**Out of scope:** `--debug` / README (PR1), other `cast()` sites (`session_stats.py`, `export_state_store.py`, `api/_flask_types.py`), rejecting extra top-level keys (optional follow-up).
## Test plan
- [x] `pytest tests/test_jsonl_validation.py tests/test_jsonl_parser.py -v`
- [x] `pytest -q` (full suite)
- [x] `mypy -p api -p utils -p models`
```powershell
cd claude-code-chat-browser
pip install -r requirements-dev.txt
pytest tests/test_jsonl_validation.py tests/test_jsonl_parser.py -v
pytest -q
mypy -p api -p utils -p models
Acceptance criteria

 Validation replaces cast() at JSONL-to-TypedDict boundary

 Invalid shapes raise SessionValidationError (not bare TypeError)

 ≥5 malformed-input tests (missing field, wrong type, null role, metadata not dict, message not dict)

 session_minimal.jsonl parses unchanged; no regressions in test_jsonl_parser.py

 mypy --strict clean on api, utils, models

 No new runtime dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session data is now validated at load with clearer, domain-specific errors that report the exact field/path and detail for failures.
  * CLI startup now respects a new --debug flag and enables the auto-reloader only when appropriate for the platform.

* **Documentation**
  * Security note added: running with host 0.0.0.0 and debug enabled is unsafe on untrusted networks; prefer the default host and disable debug.

* **Tests**
  * Added comprehensive validation and regression tests and updated CLI tests to verify debug/reloader behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/claude-code-chat-browser/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->