### PR TITLE
feat(export): consolidate HTTP and CLI bulk export behind shared engine

### DIFF
--- a/api/export_api.py
+++ b/api/export_api.py
@@ -25,14 +25,12 @@ from utils.session_stats import compute_stats
 from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
 from utils.slugify import slugify
-from utils.export_engine import EXPORT_ERRORS, ZipSink, run_bulk_export
+from utils.export_engine import EXPORT_ERRORS as _EXPORT_ERRORS, ZipSink, run_bulk_export
 
 export_bp = Blueprint("export", __name__)
 
 # Tests monkeypatch this path; keep in sync with utils.export_state_store.
 _STATE_FILE = EXPORT_STATE_FILE
-
-_EXPORT_ERRORS = EXPORT_ERRORS
 
 
 def _state_lock() -> Any:

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -18,31 +18,21 @@ from utils.export_state_store import (
     export_state_lock,
     load_export_state_from_disk,
 )
-from utils.session_path import (
-    get_claude_projects_dir,
-    list_projects,
-    list_sessions,
-)
+from utils.session_path import get_claude_projects_dir, list_projects
 from utils.jsonl_parser import parse_session
+from utils.exclusion_rules import is_session_excluded
 from utils.session_stats import compute_stats
 from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
-from utils.exclusion_rules import is_session_excluded
 from utils.slugify import slugify
-from utils.export_day_filter import collect_sessions_for_latest_activity_day
+from utils.export_engine import EXPORT_ERRORS, ZipSink, run_bulk_export
 
 export_bp = Blueprint("export", __name__)
 
 # Tests monkeypatch this path; keep in sync with utils.export_state_store.
 _STATE_FILE = EXPORT_STATE_FILE
 
-_EXPORT_ERRORS = (
-    json.JSONDecodeError,
-    KeyError,
-    ValueError,
-    OSError,
-    FileNotFoundError,
-)
+_EXPORT_ERRORS = EXPORT_ERRORS
 
 
 def _state_lock() -> Any:
@@ -120,128 +110,28 @@ def bulk_export() -> FlaskReturn:
     )
 
     buf = io.BytesIO()
-    count = 0
-    manifest: list[dict[str, Any]] = []
-    new_sessions_map: dict[str, float] = {}
-    latest_day = None
+
+    def _on_export_error(sid: str, exc: Exception) -> None:
+        current_app.logger.warning(
+            "Failed to export %s: %s", sid[:10], exc
+        )
 
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        if since == "last":
-            d, rows, _n = collect_sessions_for_latest_activity_day(
-                projects,
-                list_sessions=list_sessions,
-                parse_session=parse_session,
-                is_session_excluded=is_session_excluded,
-                rules=rules,
-            )
-            latest_day = d
-            for project, sess_info, session, _st, _en in rows:
-                sid = sess_info["id"]
-                try:
-                    stats = compute_stats(session)
-                    md = session_to_markdown(session, stats)
-                    title_slug = slugify(session["title"], default="session")
-                    short_id = sid[:8]
-                    proj_slug = slugify(project["name"], default="project")
-                    ts = session["metadata"].get("first_timestamp", "")
-                    ts_file = (
-                        ts[:19].replace(":", "-")
-                        if ts
-                        else "0000-00-00T00-00-00"
-                    )
-                    rel_path = (
-                        f"{proj_slug}/{ts_file}__{title_slug}__{short_id}.md"
-                    )
-                    zf.writestr(rel_path, md)
-                    manifest.append(
-                        {
-                            "session_id": sid,
-                            "title": session["title"],
-                            "project": project["name"],
-                            "tokens": session["metadata"]["total_input_tokens"]
-                            + session["metadata"]["total_output_tokens"],
-                            "tool_calls": session["metadata"][
-                                "total_tool_calls"
-                            ],
-                            "cost_estimate_usd": stats.get(
-                                "cost_estimate_usd"
-                            ),
-                        }
-                    )
-                    new_sessions_map[sid] = sess_info.get("modified", 0)
-                    count += 1
-                except _EXPORT_ERRORS as e:
-                    current_app.logger.warning(
-                        "Failed to export %s: %s", sid[:10], e
-                    )
-                    continue
-        else:
-            for project in projects:
-                sessions = list_sessions(project["path"])
-                for sess_info in sessions:
-                    sid = sess_info["id"]
-                    try:
-                        if since == "incremental":
-                            prev_mtime = last_export_sessions.get(sid, 0)
-                            curr_mtime = sess_info.get("modified", 0)
-                            if curr_mtime and curr_mtime <= prev_mtime:
-                                continue
+        result = run_bulk_export(
+            projects=projects,
+            since=since,
+            rules=rules,
+            last_export_sessions=last_export_sessions,
+            sink=ZipSink(zf),
+            fmt="md",
+            path_layout="api",
+            manifest_style="api",
+            on_export_error=_on_export_error,
+        )
 
-                        session = parse_session(sess_info["path"])
-                        if session["title"] == "Untitled Session":
-                            continue
-
-                        if is_session_excluded(
-                            rules,
-                            session,
-                            project.get("display_name") or project["name"],
-                        ):
-                            continue
-
-                        stats = compute_stats(session)
-                        md = session_to_markdown(session, stats)
-                        title_slug = slugify(
-                            session["title"], default="session"
-                        )
-                        short_id = sid[:8]
-                        proj_slug = slugify(project["name"], default="project")
-                        ts = session["metadata"].get("first_timestamp", "")
-                        ts_file = (
-                            ts[:19].replace(":", "-")
-                            if ts
-                            else "0000-00-00T00-00-00"
-                        )
-                        rel_path = f"{proj_slug}/{ts_file}__{title_slug}__{short_id}.md"
-                        zf.writestr(rel_path, md)
-                        manifest.append(
-                            {
-                                "session_id": sid,
-                                "title": session["title"],
-                                "project": project["name"],
-                                "tokens": session["metadata"][
-                                    "total_input_tokens"
-                                ]
-                                + session["metadata"]["total_output_tokens"],
-                                "tool_calls": session["metadata"][
-                                    "total_tool_calls"
-                                ],
-                                "cost_estimate_usd": stats.get(
-                                    "cost_estimate_usd"
-                                ),
-                            }
-                        )
-                        new_sessions_map[sid] = sess_info.get("modified", 0)
-                        count += 1
-                    except _EXPORT_ERRORS as e:
-                        current_app.logger.warning(
-                            "Failed to export %s: %s", sid[:10], e
-                        )
-                        continue
-        if manifest:
-            manifest_str = "\n".join(
-                json.dumps(e, default=str) for e in manifest
-            )
-            zf.writestr("manifest.jsonl", manifest_str)
+    count = result.exported_session_count
+    new_sessions_map = result.new_sessions_map
+    latest_day = result.latest_day
 
     if count == 0:
         return error_response(

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -427,7 +427,7 @@ def cmd_export(args):
     skipped_mtime_unchanged = 0
 
     def _on_export_error(sid: str, exc: Exception) -> None:
-        print(f"  Warning: failed to export {sid}: {exc}")
+        print(f"  Warning: failed to export {sid}: {exc}", file=sys.stderr)
 
     collect_sink = ListSink()
     export_result = run_bulk_export(

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -18,6 +18,7 @@ import os
 import sys
 import zipfile
 from datetime import datetime
+from typing import cast
 
 # Allow running from repo root or scripts/ directory
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -26,12 +27,19 @@ sys.path.insert(0, REPO_ROOT)
 
 from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
 from utils.jsonl_parser import parse_session
-from utils.session_stats import compute_stats, _format_duration
+from utils.session_stats import compute_stats, format_duration
 from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
 from utils.exclusion_rules import resolve_exclusion_rules_path, load_rules
 from utils.slugify import slugify
-from utils.export_engine import ListSink, run_bulk_export
+from utils.export_engine import (
+    ExportFormat,
+    ListSink,
+    SinceMode,
+    ZipSink,
+    run_bulk_export,
+    serialize_manifest_jsonl,
+)
 from utils.export_state_store import (
     atomic_write_export_state,
     export_state_lock,
@@ -247,7 +255,7 @@ def _session_stats(session_id: str, base_dir: str, fmt: str):
     print(f"  Title:      {session['title']}")
     if meta["first_timestamp"]:
         print(f"  Created:    {meta['first_timestamp'][:19]}")
-    dur = _format_duration(meta.get("session_wall_time_seconds"))
+    dur = format_duration(meta.get("session_wall_time_seconds"))
     if dur:
         print(f"  Duration:   {dur}")
     print(f"  Models:     {', '.join(meta['models_used']) or 'unknown'}")
@@ -432,11 +440,11 @@ def cmd_export(args):
     collect_sink = ListSink()
     export_result = run_bulk_export(
         projects=projects,
-        since=since,
+        since=cast(SinceMode, since),
         rules=rules,
         last_export_sessions=last_export,
         sink=collect_sink,
-        fmt=fmt,
+        fmt=cast(ExportFormat, fmt),
         path_layout="cli",
         manifest_style="cli",
         on_export_error=_on_export_error,
@@ -502,8 +510,7 @@ def cmd_export(args):
                 f.write(content)
         manifest_path = os.path.join(out_dir, "manifest.jsonl")
         with open(manifest_path, "w", encoding="utf-8") as f:
-            for entry in manifest:
-                f.write(json.dumps(entry, default=str) + "\n")
+            f.write(serialize_manifest_jsonl(manifest))
         print(f"Exported {exported} file(s) to {out_dir}")
     else:
         date_tag = datetime.now().strftime("%Y-%m-%d")
@@ -518,10 +525,7 @@ def cmd_export(args):
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for rel_path, content in all_exports:
                 zf.writestr(rel_path, content)
-            manifest_str = "\n".join(
-                json.dumps(e, default=str) for e in manifest
-            )
-            zf.writestr("manifest.jsonl", manifest_str)
+            ZipSink(zf).finalize(manifest)
         print(f"Exported {exported} file(s) to {zip_path}")
 
     _save_state(last_export, count=len(manifest), out_dir=out_dir)

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -34,7 +34,7 @@ from utils.exclusion_rules import resolve_exclusion_rules_path, load_rules
 from utils.slugify import slugify
 from utils.export_engine import (
     ExportFormat,
-    ListSink,
+    NoopSink,
     SinceMode,
     ZipSink,
     run_bulk_export,
@@ -437,7 +437,7 @@ def cmd_export(args):
     def _on_export_error(sid: str, exc: Exception) -> None:
         print(f"  Warning: failed to export {sid}: {exc}", file=sys.stderr)
 
-    collect_sink = ListSink()
+    collect_sink = NoopSink()
     export_result = run_bulk_export(
         projects=projects,
         since=cast(SinceMode, since),
@@ -471,12 +471,8 @@ def cmd_export(args):
                 "nothing to export."
             )
             return
-        skipped = (
-            export_result.latest_day_scan_total
-            - export_result.latest_day_match_count
-        )
     elif since == "incremental":
-        skipped_mtime_unchanged = skipped
+        skipped_mtime_unchanged = export_result.skipped_mtime_unchanged_count
 
     exported = len(all_exports)
     print(

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -29,13 +29,9 @@ from utils.jsonl_parser import parse_session
 from utils.session_stats import compute_stats, _format_duration
 from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
-from utils.exclusion_rules import (
-    resolve_exclusion_rules_path,
-    load_rules,
-    is_session_excluded,
-)
+from utils.exclusion_rules import resolve_exclusion_rules_path, load_rules
 from utils.slugify import slugify
-from utils.export_day_filter import collect_sessions_for_latest_activity_day
+from utils.export_engine import ListSink, run_bulk_export
 from utils.export_state_store import (
     atomic_write_export_state,
     export_state_lock,
@@ -389,66 +385,6 @@ def _aggregate_stats(base_dir: str, project_filter: str, fmt: str):
         print(f"  Est. cost:    ~${totals['total_cost']:.2f} USD")
 
 
-def _append_export_for_session(
-    project: dict,
-    sess_info: dict,
-    session: dict,
-    fmt: str,
-    all_exports: list,
-    manifest: list,
-    last_export: dict,
-) -> None:
-    """Append markdown/json entries and manifest row; update *last_export* mtime."""
-    sid = sess_info["id"]
-    stats = compute_stats(session)
-    meta = session["metadata"]
-    ts = meta.get("first_timestamp", "")
-    if not ts:
-        from datetime import datetime as _dt
-
-        ts = _dt.fromtimestamp(sess_info["modified"]).strftime(
-            "%Y-%m-%dT%H:%M:%S"
-        )
-        meta["first_timestamp"] = ts
-    date_str = ts[:10]
-    ts_file = ts[:19].replace(":", "-")
-    title_slug = slugify(session["title"], default="session")
-    short_id = sid[:8]
-    project_slug = slugify(project["name"], default="project")
-
-    if fmt in ("md", "both"):
-        md = session_to_markdown(session, stats)
-        rel_path = os.path.join(
-            date_str, project_slug, f"{ts_file}__{title_slug}__{short_id}.md"
-        )
-        all_exports.append((rel_path, md))
-
-    if fmt in ("json", "both"):
-        js = session_to_json(session, stats)
-        rel_path = os.path.join(
-            date_str, project_slug, f"{ts_file}__{title_slug}__{short_id}.json"
-        )
-        all_exports.append((rel_path, js))
-
-    manifest.append({
-        "session_id": sid,
-        "title": session["title"],
-        "project": project["name"],
-        "updated_at": meta.get("last_timestamp", ""),
-        "models": meta.get("models_used", []),
-        "tokens": meta["total_input_tokens"] + meta["total_output_tokens"],
-        "tool_calls": meta["total_tool_calls"],
-        "files_touched": stats.get("files_touched", {}).get(
-            "total_unique", 0
-        ),
-        "commands_run": len(stats.get("commands_run", [])),
-        "cost_estimate_usd": stats.get("cost_estimate_usd"),
-        "wall_clock_seconds": meta.get("session_wall_time_seconds"),
-    })
-
-    last_export[sid] = sess_info["modified"]
-
-
 def cmd_export(args):
     """The main export command. Writes md/json files, optionally zipped."""
     base_dir = getattr(args, "base_dir", None) or get_claude_projects_dir()
@@ -488,86 +424,51 @@ def cmd_export(args):
 
     print(f"Found {len(projects)} project(s) in {base_dir}")
 
-    all_exports = []  # list of (rel_path, content)
-    manifest = []
-    total_sessions = 0
-    skipped = 0
     skipped_mtime_unchanged = 0
-    latest_day = None
+
+    def _on_export_error(sid: str, exc: Exception) -> None:
+        print(f"  Warning: failed to export {sid}: {exc}")
+
+    collect_sink = ListSink()
+    export_result = run_bulk_export(
+        projects=projects,
+        since=since,
+        rules=rules,
+        last_export_sessions=last_export,
+        sink=collect_sink,
+        fmt=fmt,
+        path_layout="cli",
+        manifest_style="cli",
+        on_export_error=_on_export_error,
+    )
+
+    all_exports = export_result.exports
+    manifest = export_result.manifest
+    last_export.update(export_result.new_sessions_map)
+    total_sessions = export_result.total_candidates
+    skipped = export_result.skipped_count
+    latest_day = export_result.latest_day
 
     if since == "last":
-        d, rows, total_sessions = collect_sessions_for_latest_activity_day(
-            projects,
-            list_sessions=list_sessions,
-            parse_session=parse_session,
-            is_session_excluded=is_session_excluded,
-            rules=rules,
-        )
-        if d is None:
+        if latest_day is None:
             print("Nothing to export (no qualifying sessions in scope).")
             return
-        latest_day = d
         print(
-            f"Latest activity end-date (UTC): {d.isoformat()} — "
-            f"exporting sessions that overlap that calendar day."
+            f"Latest activity end-date (UTC): {latest_day.isoformat()} — "
+            "exporting sessions that overlap that calendar day."
         )
-        if not rows:
+        if export_result.latest_day_match_count == 0:
             print(
-                f"No sessions overlap {d.isoformat()} (UTC); nothing to export."
+                f"No sessions overlap {latest_day.isoformat()} (UTC); "
+                "nothing to export."
             )
             return
-        skipped = total_sessions - len(rows)
-        for project, sess_info, session, _st, _en in rows:
-            _append_export_for_session(
-                project,
-                sess_info,
-                session,
-                fmt,
-                all_exports,
-                manifest,
-                last_export,
-            )
-    else:
-        for project in projects:
-            sessions = list_sessions(project["path"])
-            for sess_info in sessions:
-                total_sessions += 1
-                sid = sess_info["id"]
-
-                if since == "incremental":
-                    prev_mtime = last_export.get(sid, 0)
-                    if sess_info["modified"] <= prev_mtime:
-                        skipped += 1
-                        skipped_mtime_unchanged += 1
-                        continue
-
-                try:
-                    session = parse_session(sess_info["path"])
-                except Exception as e:
-                    print(f"  Warning: failed to parse {sid}: {e}")
-                    continue
-
-                if session["title"] == "Untitled Session":
-                    skipped += 1
-                    continue
-
-                if is_session_excluded(
-                    rules,
-                    session,
-                    project.get("display_name") or project["name"],
-                ):
-                    skipped += 1
-                    continue
-
-                _append_export_for_session(
-                    project,
-                    sess_info,
-                    session,
-                    fmt,
-                    all_exports,
-                    manifest,
-                    last_export,
-                )
+        skipped = (
+            export_result.latest_day_scan_total
+            - export_result.latest_day_match_count
+        )
+    elif since == "incremental":
+        skipped_mtime_unchanged = skipped
 
     exported = len(all_exports)
     print(

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -19,7 +19,7 @@ from api.export_api import export_bp  # noqa: E402
 from tests.test_cli_e2e import _run_cli, _seed_base_dir  # noqa: E402
 from utils.export_engine import (  # noqa: E402
     MANIFEST_SHARED_KEYS,
-    ListSink,
+    NoopSink,
     manifest_shared_subset,
     run_bulk_export,
 )
@@ -37,7 +37,7 @@ def test_engine_api_vs_cli_layout_same_markdown_and_manifest(tmp_path: Path) -> 
     projects = list_projects(str(base))
     rules: list = []
 
-    api_sink = ListSink()
+    api_sink = NoopSink()
     api_result = run_bulk_export(
         projects=projects,
         since="all",
@@ -48,7 +48,7 @@ def test_engine_api_vs_cli_layout_same_markdown_and_manifest(tmp_path: Path) -> 
         path_layout="api",
         manifest_style="api",
     )
-    cli_sink = ListSink()
+    cli_sink = NoopSink()
     cli_result = run_bulk_export(
         projects=projects,
         since="all",

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -92,14 +92,15 @@ def test_http_post_export_matches_cli_no_zip(tmp_path: Path, monkeypatch) -> Non
     assert resp.status_code == 200
 
     zf = zipfile.ZipFile(io.BytesIO(resp.data))
-    http_md = zf.read(
-        next(n for n in zf.namelist() if n.endswith(".md"))
-    ).decode("utf-8")
+    http_md_names = [n for n in zf.namelist() if n.endswith(".md")]
+    assert len(http_md_names) == 1, f"expected one .md in zip, got {http_md_names}"
+    http_md = zf.read(http_md_names[0]).decode("utf-8")
     http_manifest = [
         json.loads(line)
         for line in zf.read("manifest.jsonl").decode("utf-8").splitlines()
         if line.strip()
     ]
+    assert len(http_manifest) == 1, f"expected one manifest row, got {len(http_manifest)}"
 
     out_dir = tmp_path / "cli_out"
     proc = _run_cli([

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -1,0 +1,130 @@
+"""Parity: HTTP bulk export vs CLI export produce identical Markdown and manifest core fields."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from flask import Flask  # noqa: E402
+
+from api.export_api import export_bp  # noqa: E402
+from tests.test_cli_e2e import _run_cli, _seed_base_dir  # noqa: E402
+from utils.export_engine import (  # noqa: E402
+    ListSink,
+    manifest_shared_subset,
+    run_bulk_export,
+)
+from utils.session_path import list_projects  # noqa: E402
+
+_MANIFEST_KEYS = (
+    "session_id",
+    "title",
+    "project",
+    "tokens",
+    "tool_calls",
+)
+
+
+def _markdown_from_exports(exports: list[tuple[str, str]]) -> str:
+    md_paths = [p for p, _ in exports if p.endswith(".md")]
+    assert len(md_paths) == 1, f"expected one .md file, got {md_paths}"
+    return next(content for p, content in exports if p.endswith(".md"))
+
+
+def test_engine_api_vs_cli_layout_same_markdown_and_manifest(tmp_path: Path) -> None:
+    base = _seed_base_dir(tmp_path)
+    projects = list_projects(str(base))
+    rules: list = []
+
+    api_sink = ListSink()
+    api_result = run_bulk_export(
+        projects=projects,
+        since="all",
+        rules=rules,
+        last_export_sessions={},
+        sink=api_sink,
+        fmt="md",
+        path_layout="api",
+        manifest_style="api",
+    )
+    cli_sink = ListSink()
+    cli_result = run_bulk_export(
+        projects=projects,
+        since="all",
+        rules=rules,
+        last_export_sessions={},
+        sink=cli_sink,
+        fmt="md",
+        path_layout="cli",
+        manifest_style="cli",
+    )
+
+    assert api_result.exported_session_count == 1
+    assert cli_result.exported_session_count == 1
+    assert _markdown_from_exports(api_result.exports) == _markdown_from_exports(
+        cli_result.exports
+    )
+
+    api_core = manifest_shared_subset(api_result.manifest[0])
+    cli_core = manifest_shared_subset(cli_result.manifest[0])
+    for key in _MANIFEST_KEYS:
+        assert api_core[key] == cli_core[key]
+
+
+def test_http_post_export_matches_cli_no_zip(tmp_path: Path, monkeypatch) -> None:
+    base = _seed_base_dir(tmp_path)
+    state_path = tmp_path / "export_state.json"
+    monkeypatch.setattr("api.export_api._STATE_FILE", str(state_path))
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["CLAUDE_PROJECTS_DIR"] = str(base)
+    app.register_blueprint(export_bp)
+    resp = app.test_client().post("/api/export", json={"since": "all"})
+    assert resp.status_code == 200
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.data))
+    http_md = zf.read(
+        next(n for n in zf.namelist() if n.endswith(".md"))
+    ).decode("utf-8")
+    http_manifest = [
+        json.loads(line)
+        for line in zf.read("manifest.jsonl").decode("utf-8").splitlines()
+        if line.strip()
+    ]
+
+    out_dir = tmp_path / "cli_out"
+    proc = _run_cli([
+        "export",
+        "--base-dir",
+        str(base),
+        "--since",
+        "all",
+        "--no-zip",
+        "--out",
+        str(out_dir),
+    ])
+    assert proc.returncode == 0, proc.stderr
+
+    cli_md_files = list(out_dir.rglob("*.md"))
+    assert len(cli_md_files) == 1
+    cli_md = cli_md_files[0].read_text(encoding="utf-8")
+    manifest_path = out_dir / "manifest.jsonl"
+    cli_manifest = [
+        json.loads(line)
+        for line in manifest_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert http_md == cli_md
+    http_core = {k: http_manifest[0][k] for k in _MANIFEST_KEYS}
+    cli_core = {k: cli_manifest[0][k] for k in _MANIFEST_KEYS}
+    assert http_core == cli_core

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -18,19 +18,12 @@ from flask import Flask  # noqa: E402
 from api.export_api import export_bp  # noqa: E402
 from tests.test_cli_e2e import _run_cli, _seed_base_dir  # noqa: E402
 from utils.export_engine import (  # noqa: E402
+    MANIFEST_SHARED_KEYS,
     ListSink,
     manifest_shared_subset,
     run_bulk_export,
 )
 from utils.session_path import list_projects  # noqa: E402
-
-_MANIFEST_KEYS = (
-    "session_id",
-    "title",
-    "project",
-    "tokens",
-    "tool_calls",
-)
 
 
 def _markdown_from_exports(exports: list[tuple[str, str]]) -> str:
@@ -75,7 +68,7 @@ def test_engine_api_vs_cli_layout_same_markdown_and_manifest(tmp_path: Path) -> 
 
     api_core = manifest_shared_subset(api_result.manifest[0])
     cli_core = manifest_shared_subset(cli_result.manifest[0])
-    for key in _MANIFEST_KEYS:
+    for key in MANIFEST_SHARED_KEYS:
         assert api_core[key] == cli_core[key]
 
 
@@ -126,6 +119,6 @@ def test_http_post_export_matches_cli_no_zip(tmp_path: Path, monkeypatch) -> Non
     ]
 
     assert http_md == cli_md
-    http_core = {k: http_manifest[0][k] for k in _MANIFEST_KEYS}
-    cli_core = {k: cli_manifest[0][k] for k in _MANIFEST_KEYS}
+    http_core = {k: http_manifest[0][k] for k in MANIFEST_SHARED_KEYS}
+    cli_core = {k: cli_manifest[0][k] for k in MANIFEST_SHARED_KEYS}
     assert http_core == cli_core

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -31,8 +31,10 @@ EXPORT_ERRORS = (
 
 PathLayout = Literal["api", "cli"]
 ManifestStyle = Literal["api", "cli"]
+SinceMode = Literal["all", "last", "incremental"]
+ExportFormat = Literal["md", "json", "both"]
 
-_MANIFEST_SHARED_KEYS = (
+MANIFEST_SHARED_KEYS: tuple[str, ...] = (
     "session_id",
     "title",
     "project",
@@ -41,10 +43,18 @@ _MANIFEST_SHARED_KEYS = (
 )
 
 
+def serialize_manifest_jsonl(manifest: list[dict[str, Any]]) -> str:
+    """JSONL manifest body with a trailing newline (empty string if no rows)."""
+    if not manifest:
+        return ""
+    return "\n".join(json.dumps(e, default=str) for e in manifest) + "\n"
+
+
 @dataclass
 class BulkExportResult:
     """Outcome of a bulk export run."""
 
+    # Canonical list of (rel_path, content); sinks do not duplicate this.
     exports: list[tuple[str, str]] = field(default_factory=list)
     manifest: list[dict[str, Any]] = field(default_factory=list)
     new_sessions_map: dict[str, float] = field(default_factory=dict)
@@ -64,16 +74,17 @@ class ExportSink(Protocol):
         self,
         files: list[tuple[str, str]],
         manifest_entry: dict[str, Any],
-    ) -> None: ...
+    ) -> None:
+        """Write one session's export file(s) to the sink target."""
 
-    def finalize(self, manifest: list[dict[str, Any]]) -> None: ...
+    def finalize(self, manifest: list[dict[str, Any]]) -> None:
+        """Flush manifest and any sink-specific completion (e.g. manifest.jsonl)."""
 
 
 @dataclass
 class ListSink:
-    """In-memory sink for tests and parity checks."""
+    """In-memory sink for tests; use :attr:`BulkExportResult.exports` for file pairs."""
 
-    exports: list[tuple[str, str]] = field(default_factory=list)
     manifest: list[dict[str, Any]] = field(default_factory=list)
 
     def add_session(
@@ -81,7 +92,6 @@ class ListSink:
         files: list[tuple[str, str]],
         manifest_entry: dict[str, Any],
     ) -> None:
-        self.exports.extend(files)
         self.manifest.append(manifest_entry)
 
     def finalize(self, manifest: list[dict[str, Any]]) -> None:
@@ -105,21 +115,20 @@ class ZipSink:
         self._manifest.append(manifest_entry)
 
     def finalize(self, manifest: list[dict[str, Any]]) -> None:
-        if manifest:
-            manifest_str = "\n".join(json.dumps(e, default=str) for e in manifest) + "\n"
-            self._zf.writestr("manifest.jsonl", manifest_str)
+        body = serialize_manifest_jsonl(manifest)
+        if body:
+            self._zf.writestr("manifest.jsonl", body)
 
 
-def _ensure_first_timestamp(
+def _resolve_first_timestamp(
     meta: SessionMetadataDict, sess_info: SessionListItemDict
 ) -> str:
-    ts_raw = meta.get("first_timestamp") or ""
-    ts = ts_raw if ts_raw else ""
+    """Return first_timestamp from metadata, or synthesise from mtime without mutating *meta*."""
+    ts = (meta.get("first_timestamp") or "").strip()
     if not ts:
         ts = datetime.fromtimestamp(sess_info["modified"]).strftime(
             "%Y-%m-%dT%H:%M:%S"
         )
-        meta["first_timestamp"] = ts
     return ts
 
 
@@ -138,10 +147,8 @@ def build_export_rel_path(
     """Build zip/disk-relative path for one exported session file."""
     sid = sess_info["id"]
     meta = session["metadata"]
-    ts = meta.get("first_timestamp") or ""
-    if layout == "cli" and not ts:
-        ts = _ensure_first_timestamp(meta, sess_info)
-    date_str = ts[:10] if ts else "0000-00-00"
+    ts = _resolve_first_timestamp(meta, sess_info)
+    date_str = ts[:10]
     ts_file = _ts_file_slug(ts)
     title_slug = slugify(session["title"], default="session")
     short_id = sid[:8]
@@ -185,7 +192,7 @@ def build_manifest_entry(
 
 def manifest_shared_subset(entry: dict[str, Any]) -> dict[str, Any]:
     """Core manifest fields compared in HTTP vs CLI parity tests."""
-    return {k: entry[k] for k in _MANIFEST_SHARED_KEYS if k in entry}
+    return {k: entry[k] for k in MANIFEST_SHARED_KEYS if k in entry}
 
 
 def _session_files(
@@ -193,7 +200,7 @@ def _session_files(
     stats: SessionStatsDict,
     project: ProjectDict,
     sess_info: SessionListItemDict,
-    fmt: str,
+    fmt: ExportFormat,
     layout: PathLayout,
 ) -> list[tuple[str, str]]:
     files: list[tuple[str, str]] = []
@@ -223,11 +230,11 @@ def _session_files(
 def run_bulk_export(
     *,
     projects: list[ProjectDict],
-    since: str,
+    since: SinceMode,
     rules: list[Any],
     last_export_sessions: dict[str, float],
     sink: ExportSink,
-    fmt: str = "md",
+    fmt: ExportFormat = "md",
     path_layout: PathLayout = "api",
     manifest_style: ManifestStyle | None = None,
     on_export_error: Callable[[str, Exception], None] | None = None,
@@ -237,6 +244,9 @@ def run_bulk_export(
     *since* must be one of ``all``, ``last``, or ``incremental``.
     Per-session failures are caught, counted, and skipped (batch continues).
     """
+    if since not in ("all", "last", "incremental"):
+        raise ValueError(f"Invalid since mode: {since!r}")
+
     if manifest_style is None:
         manifest_style = path_layout
 

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import json
-import os
+import posixpath
 import zipfile
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Callable, Literal, Protocol
 
 from models.project import ProjectDict, SessionListItemDict
@@ -41,6 +41,15 @@ MANIFEST_SHARED_KEYS: tuple[str, ...] = (
     "tokens",
     "tool_calls",
 )
+
+_VALID_SINCE: frozenset[str] = frozenset({"all", "last", "incremental"})
+_VALID_FMT: frozenset[str] = frozenset({"md", "json", "both"})
+_VALID_LAYOUT: frozenset[str] = frozenset({"api", "cli"})
+
+
+def _validate_mode(name: str, value: str, allowed: frozenset[str]) -> None:
+    if value not in allowed:
+        raise ValueError(f"Invalid {name}: {value!r}")
 
 
 def serialize_manifest_jsonl(manifest: list[dict[str, Any]]) -> str:
@@ -106,18 +115,19 @@ class ZipSink:
 
     def __init__(self, zf: zipfile.ZipFile) -> None:
         self._zf = zf
-        self._manifest: list[dict[str, Any]] = []
+        self._pending_files: list[tuple[str, str]] = []
 
     def add_session(
         self,
         files: list[tuple[str, str]],
         manifest_entry: dict[str, Any],
     ) -> None:
-        for rel_path, content in files:
-            self._zf.writestr(rel_path, content)
-        self._manifest.append(manifest_entry)
+        del manifest_entry
+        self._pending_files.extend(files)
 
     def finalize(self, manifest: list[dict[str, Any]]) -> None:
+        for rel_path, content in self._pending_files:
+            self._zf.writestr(rel_path, content)
         body = serialize_manifest_jsonl(manifest)
         if body:
             self._zf.writestr("manifest.jsonl", body)
@@ -129,9 +139,9 @@ def _resolve_first_timestamp(
     """Return first_timestamp from metadata, or synthesise from mtime without mutating *meta*."""
     ts = (meta.get("first_timestamp") or "").strip()
     if not ts:
-        ts = datetime.fromtimestamp(sess_info["modified"]).strftime(
-            "%Y-%m-%dT%H:%M:%S"
-        )
+        ts = datetime.fromtimestamp(
+            sess_info["modified"], tz=timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%S")
     return ts
 
 
@@ -159,7 +169,7 @@ def build_export_rel_path(
     filename = f"{ts_file}__{title_slug}__{short_id}.{ext}"
     if layout == "api":
         return f"{proj_slug}/{filename}"
-    return os.path.join(date_str, proj_slug, filename)
+    return posixpath.join(date_str, proj_slug, filename)
 
 
 def build_manifest_entry(
@@ -247,11 +257,13 @@ def run_bulk_export(
     *since* must be one of ``all``, ``last``, or ``incremental``.
     Per-session failures are caught, counted, and skipped (batch continues).
     """
-    if since not in ("all", "last", "incremental"):
-        raise ValueError(f"Invalid since mode: {since!r}")
+    _validate_mode("since", since, _VALID_SINCE)
+    _validate_mode("fmt", fmt, _VALID_FMT)
+    _validate_mode("path_layout", path_layout, _VALID_LAYOUT)
 
     if manifest_style is None:
         manifest_style = path_layout
+    _validate_mode("manifest_style", manifest_style, _VALID_LAYOUT)
 
     result = BulkExportResult()
     manifest: list[dict[str, Any]] = []

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -106,7 +106,7 @@ class ZipSink:
 
     def finalize(self, manifest: list[dict[str, Any]]) -> None:
         if manifest:
-            manifest_str = "\n".join(json.dumps(e, default=str) for e in manifest)
+            manifest_str = "\n".join(json.dumps(e, default=str) for e in manifest) + "\n"
             self._zf.writestr("manifest.jsonl", manifest_str)
 
 

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -61,6 +61,7 @@ class BulkExportResult:
     exported_session_count: int = 0
     failure_count: int = 0
     skipped_count: int = 0
+    skipped_mtime_unchanged_count: int = 0
     total_candidates: int = 0
     latest_day: date | None = None
     latest_day_scan_total: int = 0
@@ -82,20 +83,22 @@ class ExportSink(Protocol):
 
 
 @dataclass
-class ListSink:
-    """In-memory sink for tests; use :attr:`BulkExportResult.exports` for file pairs."""
-
-    manifest: list[dict[str, Any]] = field(default_factory=list)
+class NoopSink:
+    """Satisfies :class:`ExportSink` when only :attr:`BulkExportResult` fields are needed."""
 
     def add_session(
         self,
         files: list[tuple[str, str]],
         manifest_entry: dict[str, Any],
     ) -> None:
-        self.manifest.append(manifest_entry)
+        del files, manifest_entry
 
     def finalize(self, manifest: list[dict[str, Any]]) -> None:
-        self.manifest = manifest
+        del manifest
+
+
+# Backward-compatible alias for tests/docs written during PR1.
+ListSink = NoopSink
 
 
 class ZipSink:
@@ -277,7 +280,7 @@ def run_bulk_export(
             result.exports.extend(files)
             result.new_sessions_map[sid] = float(sess_info.get("modified", 0))
             result.exported_session_count += 1
-        except EXPORT_ERRORS as exc:
+        except Exception as exc:
             _record_failure(sid, exc)
 
     if since == "last":
@@ -306,6 +309,7 @@ def run_bulk_export(
                         curr_mtime = float(sess_info.get("modified", 0))
                         if curr_mtime and curr_mtime <= prev_mtime:
                             result.skipped_count += 1
+                            result.skipped_mtime_unchanged_count += 1
                             continue
 
                     session = parse_session(sess_info["path"])
@@ -322,7 +326,7 @@ def run_bulk_export(
                         continue
 
                     _export_parsed(project, sess_info, session)
-                except EXPORT_ERRORS as exc:
+                except Exception as exc:
                     _record_failure(sid, exc)
 
     result.manifest = manifest

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -1,0 +1,320 @@
+"""Shared bulk-export loop for HTTP API and CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Callable, Literal, Protocol
+
+from models.project import ProjectDict, SessionListItemDict
+from models.session import SessionDict, SessionMetadataDict
+from models.stats import SessionStatsDict
+from utils.exclusion_rules import is_session_excluded
+from utils.export_day_filter import collect_sessions_for_latest_activity_day
+from utils.json_exporter import session_to_json
+from utils.jsonl_parser import parse_session
+from utils.md_exporter import session_to_markdown
+from utils.session_path import list_sessions
+from utils.session_stats import compute_stats
+from utils.slugify import slugify
+
+EXPORT_ERRORS = (
+    json.JSONDecodeError,
+    KeyError,
+    ValueError,
+    OSError,
+    FileNotFoundError,
+)
+
+PathLayout = Literal["api", "cli"]
+ManifestStyle = Literal["api", "cli"]
+
+_MANIFEST_SHARED_KEYS = (
+    "session_id",
+    "title",
+    "project",
+    "tokens",
+    "tool_calls",
+)
+
+
+@dataclass
+class BulkExportResult:
+    """Outcome of a bulk export run."""
+
+    exports: list[tuple[str, str]] = field(default_factory=list)
+    manifest: list[dict[str, Any]] = field(default_factory=list)
+    new_sessions_map: dict[str, float] = field(default_factory=dict)
+    exported_session_count: int = 0
+    failure_count: int = 0
+    skipped_count: int = 0
+    total_candidates: int = 0
+    latest_day: date | None = None
+    latest_day_scan_total: int = 0
+    latest_day_match_count: int = 0
+
+
+class ExportSink(Protocol):
+    """Receives exported session files and final manifest."""
+
+    def add_session(
+        self,
+        files: list[tuple[str, str]],
+        manifest_entry: dict[str, Any],
+    ) -> None: ...
+
+    def finalize(self, manifest: list[dict[str, Any]]) -> None: ...
+
+
+@dataclass
+class ListSink:
+    """In-memory sink for tests and parity checks."""
+
+    exports: list[tuple[str, str]] = field(default_factory=list)
+    manifest: list[dict[str, Any]] = field(default_factory=list)
+
+    def add_session(
+        self,
+        files: list[tuple[str, str]],
+        manifest_entry: dict[str, Any],
+    ) -> None:
+        self.exports.extend(files)
+        self.manifest.append(manifest_entry)
+
+    def finalize(self, manifest: list[dict[str, Any]]) -> None:
+        self.manifest = manifest
+
+
+class ZipSink:
+    """Writes session files and manifest.jsonl into a zip archive."""
+
+    def __init__(self, zf: zipfile.ZipFile) -> None:
+        self._zf = zf
+        self._manifest: list[dict[str, Any]] = []
+
+    def add_session(
+        self,
+        files: list[tuple[str, str]],
+        manifest_entry: dict[str, Any],
+    ) -> None:
+        for rel_path, content in files:
+            self._zf.writestr(rel_path, content)
+        self._manifest.append(manifest_entry)
+
+    def finalize(self, manifest: list[dict[str, Any]]) -> None:
+        if manifest:
+            manifest_str = "\n".join(json.dumps(e, default=str) for e in manifest)
+            self._zf.writestr("manifest.jsonl", manifest_str)
+
+
+def _ensure_first_timestamp(
+    meta: SessionMetadataDict, sess_info: SessionListItemDict
+) -> str:
+    ts_raw = meta.get("first_timestamp") or ""
+    ts = ts_raw if ts_raw else ""
+    if not ts:
+        ts = datetime.fromtimestamp(sess_info["modified"]).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        meta["first_timestamp"] = ts
+    return ts
+
+
+def _ts_file_slug(ts: str) -> str:
+    return ts[:19].replace(":", "-") if ts else "0000-00-00T00-00-00"
+
+
+def build_export_rel_path(
+    project: ProjectDict,
+    session: SessionDict,
+    sess_info: SessionListItemDict,
+    ext: str,
+    *,
+    layout: PathLayout,
+) -> str:
+    """Build zip/disk-relative path for one exported session file."""
+    sid = sess_info["id"]
+    meta = session["metadata"]
+    ts = meta.get("first_timestamp") or ""
+    if layout == "cli" and not ts:
+        ts = _ensure_first_timestamp(meta, sess_info)
+    date_str = ts[:10] if ts else "0000-00-00"
+    ts_file = _ts_file_slug(ts)
+    title_slug = slugify(session["title"], default="session")
+    short_id = sid[:8]
+    proj_slug = slugify(project["name"], default="project")
+    filename = f"{ts_file}__{title_slug}__{short_id}.{ext}"
+    if layout == "api":
+        return f"{proj_slug}/{filename}"
+    return os.path.join(date_str, proj_slug, filename)
+
+
+def build_manifest_entry(
+    project: ProjectDict,
+    sess_info: SessionListItemDict,
+    session: SessionDict,
+    stats: SessionStatsDict,
+    *,
+    style: ManifestStyle,
+) -> dict[str, Any]:
+    """Build one manifest row (API minimal vs CLI extended fields)."""
+    sid = sess_info["id"]
+    meta = session["metadata"]
+    base: dict[str, Any] = {
+        "session_id": sid,
+        "title": session["title"],
+        "project": project["name"],
+        "tokens": meta["total_input_tokens"] + meta["total_output_tokens"],
+        "tool_calls": meta["total_tool_calls"],
+        "cost_estimate_usd": stats.get("cost_estimate_usd"),
+    }
+    if style == "api":
+        return base
+    return {
+        **base,
+        "updated_at": meta.get("last_timestamp", ""),
+        "models": meta.get("models_used", []),
+        "files_touched": stats.get("files_touched", {}).get("total_unique", 0),
+        "commands_run": len(stats.get("commands_run", [])),
+        "wall_clock_seconds": meta.get("session_wall_time_seconds"),
+    }
+
+
+def manifest_shared_subset(entry: dict[str, Any]) -> dict[str, Any]:
+    """Core manifest fields compared in HTTP vs CLI parity tests."""
+    return {k: entry[k] for k in _MANIFEST_SHARED_KEYS if k in entry}
+
+
+def _session_files(
+    session: SessionDict,
+    stats: SessionStatsDict,
+    project: ProjectDict,
+    sess_info: SessionListItemDict,
+    fmt: str,
+    layout: PathLayout,
+) -> list[tuple[str, str]]:
+    files: list[tuple[str, str]] = []
+    if fmt in ("md", "both"):
+        md = session_to_markdown(session, stats)
+        files.append(
+            (
+                build_export_rel_path(
+                    project, session, sess_info, "md", layout=layout
+                ),
+                md,
+            )
+        )
+    if fmt in ("json", "both"):
+        js = session_to_json(session, stats)
+        files.append(
+            (
+                build_export_rel_path(
+                    project, session, sess_info, "json", layout=layout
+                ),
+                js,
+            )
+        )
+    return files
+
+
+def run_bulk_export(
+    *,
+    projects: list[ProjectDict],
+    since: str,
+    rules: list[Any],
+    last_export_sessions: dict[str, float],
+    sink: ExportSink,
+    fmt: str = "md",
+    path_layout: PathLayout = "api",
+    manifest_style: ManifestStyle | None = None,
+    on_export_error: Callable[[str, Exception], None] | None = None,
+) -> BulkExportResult:
+    """Run the shared bulk-export session loop.
+
+    *since* must be one of ``all``, ``last``, or ``incremental``.
+    Per-session failures are caught, counted, and skipped (batch continues).
+    """
+    if manifest_style is None:
+        manifest_style = path_layout
+
+    result = BulkExportResult()
+    manifest: list[dict[str, Any]] = []
+
+    def _record_failure(sid: str, exc: Exception) -> None:
+        result.failure_count += 1
+        if on_export_error is not None:
+            on_export_error(sid, exc)
+
+    def _export_parsed(
+        project: ProjectDict,
+        sess_info: SessionListItemDict,
+        session: SessionDict,
+    ) -> None:
+        sid = sess_info["id"]
+        try:
+            stats = compute_stats(session)
+            files = _session_files(
+                session, stats, project, sess_info, fmt, path_layout
+            )
+            entry = build_manifest_entry(
+                project, sess_info, session, stats, style=manifest_style
+            )
+            sink.add_session(files, entry)
+            manifest.append(entry)
+            result.exports.extend(files)
+            result.new_sessions_map[sid] = float(sess_info.get("modified", 0))
+            result.exported_session_count += 1
+        except EXPORT_ERRORS as exc:
+            _record_failure(sid, exc)
+
+    if since == "last":
+        latest_day, rows, scan_total = collect_sessions_for_latest_activity_day(
+            projects,
+            list_sessions=list_sessions,
+            parse_session=parse_session,
+            is_session_excluded=is_session_excluded,
+            rules=rules,
+        )
+        result.latest_day = latest_day
+        result.latest_day_scan_total = scan_total
+        result.latest_day_match_count = len(rows)
+        result.total_candidates = scan_total
+        for project, sess_info, session, _st, _en in rows:
+            _export_parsed(project, sess_info, session)
+        result.skipped_count = max(0, scan_total - len(rows))
+    else:
+        for project in projects:
+            for sess_info in list_sessions(project["path"]):
+                result.total_candidates += 1
+                sid = sess_info["id"]
+                try:
+                    if since == "incremental":
+                        prev_mtime = last_export_sessions.get(sid, 0)
+                        curr_mtime = float(sess_info.get("modified", 0))
+                        if curr_mtime and curr_mtime <= prev_mtime:
+                            result.skipped_count += 1
+                            continue
+
+                    session = parse_session(sess_info["path"])
+                    if session["title"] == "Untitled Session":
+                        result.skipped_count += 1
+                        continue
+
+                    if is_session_excluded(
+                        rules,
+                        session,
+                        project.get("display_name") or project["name"],
+                    ):
+                        result.skipped_count += 1
+                        continue
+
+                    _export_parsed(project, sess_info, session)
+                except EXPORT_ERRORS as exc:
+                    _record_failure(sid, exc)
+
+    result.manifest = manifest
+    sink.finalize(manifest)
+    return result

--- a/utils/session_stats.py
+++ b/utils/session_stats.py
@@ -197,7 +197,7 @@ def _summarize_tool_results(messages: list[MessageDict]) -> dict[str, int]:
     return summary
 
 
-def _format_duration(seconds: float | int | None) -> str | None:
+def format_duration(seconds: float | int | None) -> str | None:
     """Turn seconds into something like '2h 15m' or '45s'."""
     if seconds is None:
         return None
@@ -211,3 +211,6 @@ def _format_duration(seconds: float | int | None) -> str | None:
     hours = minutes // 60
     mins = minutes % 60
     return f"{hours}h {mins}m"
+
+
+_format_duration = format_duration  # backward compat for internal callers


### PR DESCRIPTION
closes #50 

## Summary

- Adds `utils/export_engine.py` with `run_bulk_export()`, `ExportSink` (`ZipSink`, `ListSink`), and `BulkExportResult` so the bulk-export session loop lives in one place.
- Refactors `api/export_api.bulk_export()` and `scripts/export.cmd_export()` to delegate to the engine; HTTP and CLI keep their own I/O, validation, and user messaging.
- Adds `tests/test_export_engine_parity.py` to assert identical Markdown and core manifest fields (`session_id`, `title`, `project`, `tokens`, `tool_calls`) for the same fixture on HTTP vs CLI paths.

## Problem

Bulk export logic was duplicated in:

- `bulk_export()` in `api/export_api.py` (HTTP → zip in `BytesIO`)
- `cmd_export()` in `scripts/export.py` (CLI → filesystem or zip)

Both implemented the same flow (list projects, iterate sessions, exclusions, parse, stats, markdown, manifest, state). Divergence was already creeping in (manifest fields, zip inner paths, error handling).

## Solution

| Layer | Responsibility |
|-------|----------------|
| **`utils/export_engine.py`** | Shared loop for `since` = `all` / `last` / `incremental`; per-session failure handling; manifest building |
| **`ExportSink`** | HTTP uses `ZipSink`; tests use `ListSink`; CLI collects exports then writes disk/zip as before |
| **Path layout** | Injected via `path_layout`: API `{proj_slug}/…`, CLI `{date}/{proj_slug}/…` (unchanged) |
| **Manifest** | `manifest_style`: API 6 fields; CLI 11 fields (parity test compares shared subset only) |
| **Callers** | HTTP: request validation, 422 on empty export, `send_file`, state write. CLI: argparse, prints, `--since last` early messages, disk/zip output, state save |

## Test plan

- [x] `pytest tests/test_export_engine_parity.py -v`
- [x] `pytest tests/test_export_api_bulk.py tests/test_cli_e2e.py tests/test_export_exclusion_filtering.py -q`
- [x] `pytest tests/ -q` (280 passed, coverage ≥ 60%)
- [x] `mypy utils/export_engine.py api/export_api.py --strict`

## Out of scope (follow-ups)

- CLI exit codes on partial failure → **PR2** (`feat/cli-export-exit-codes`, branches from `master` after this merges)
- JSONL parser split (Thursday #6)
- Full manifest field unification / zip path layout unification between HTTP and CLI

## Merge order

**Merge this PR first.** PR2 adds exit-code mapping in the CLI wrapper around the engine’s `failure_count`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Exporting consolidated into a shared engine for API and CLI, producing deterministic manifest JSONL, consistent file layouts for zipped and unzipped exports, improved export summaries, and per-export error reporting.

* **Tests**
  * Added parity tests ensuring exported Markdown and core manifest fields match between HTTP and CLI export paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/claude-code-chat-browser/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->