### PR TITLE
Feat/cli export exit codes

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -15,8 +15,12 @@ Exit codes (export subcommand):
   0 — all sessions exported successfully (or nothing to export, no errors)
   1 — total failure (no sessions exported; one or more errors)
   2 — partial failure (some sessions exported, some failed)
+<<<<<<< HEAD
   (0/1/2 mapping applies only to bulk export; single-session exports may exit
   0 or non-zero, e.g. cmd_export can call _die and exit 1)
+=======
+  (exit codes apply to bulk export only; --session single-export always exits 0)
+>>>>>>> fa8564b (fix(cli): accurate attempt count, elif, stdout on success in exit summary)
 """
 
 import argparse

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -15,12 +15,8 @@ Exit codes (export subcommand):
   0 — all sessions exported successfully (or nothing to export, no errors)
   1 — total failure (no sessions exported; one or more errors)
   2 — partial failure (some sessions exported, some failed)
-<<<<<<< HEAD
   (0/1/2 mapping applies only to bulk export; single-session exports may exit
   0 or non-zero, e.g. cmd_export can call _die and exit 1)
-=======
-  (exit codes apply to bulk export only; --session single-export always exits 0)
->>>>>>> fa8564b (fix(cli): accurate attempt count, elif, stdout on success in exit summary)
 """
 
 import argparse

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -15,7 +15,8 @@ Exit codes (export subcommand):
   0 — all sessions exported successfully (or nothing to export, no errors)
   1 — total failure (no sessions exported; one or more errors)
   2 — partial failure (some sessions exported, some failed)
-  (exit codes apply to bulk export only; --session single-export always exits 0)
+  (0/1/2 mapping applies only to bulk export; single-session exports may exit
+  0 or non-zero, e.g. cmd_export can call _die and exit 1)
 """
 
 import argparse

--- a/tests/test_cli_export_exit_codes.py
+++ b/tests/test_cli_export_exit_codes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 import types

--- a/tests/test_cli_export_exit_codes.py
+++ b/tests/test_cli_export_exit_codes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import sys
 import types


### PR DESCRIPTION
closes #53 

## Summary

Mechanical split of the `utils/jsonl_parser.py` monolith (~762 lines) into focused modules with no behavior change. The 15-predicate tool-result dispatch table is isolated in `utils/tool_dispatch.py` with an explicit ordering contract. `quick_session_info` moves to `utils/session_peek.py`; shared content helpers move to `utils/jsonl_helpers.py`. All existing imports from `utils.jsonl_parser` continue to work via re-exports. No test file changes.

## Changes

- `utils/tool_dispatch.py` — `_TOOL_RESULT_DISPATCH`, all `_tool_result_pred_*` / `_tool_result_build_*`, `_parse_tool_result`
- `utils/session_peek.py` — `quick_session_info()` two-pass metadata peek
- `utils/jsonl_helpers.py` — `_entry_message`, `_normalize_content`, `_extract_text`, `_extract_images`, `_infer_title`, `_strip_system_tags`
- `utils/jsonl_parser.py` (slimmed) — `parse_session()`, message processors, `_track_file_activity`, re-exports
- `docs/architecture.md` — one-line update: dispatch table lives in `utils/tool_dispatch.py`

Dispatch predicate order is unchanged (first match wins; `task_message` before narrower task arms).

## Backward compatibility

Existing imports unchanged:

- `from utils.jsonl_parser import parse_session`
- `from utils.jsonl_parser import quick_session_info`
- `from utils.jsonl_parser import _parse_tool_result, _TOOL_RESULT_DISPATCH`
- `from utils.jsonl_parser import _strip_system_tags`

## Test plan

- pytest tests/test_jsonl_parser.py tests/test_real_session_fixtures.py tests/test_jsonl_validation.py tests/test_null_usage_tokens.py -v
- pytest -q (317 tests)
- mypy -p api -p utils -p models
- Import smoke: parse_session, quick_session_info, _parse_tool_result, _TOOL_RESULT_DISPATCH from utils.jsonl_parser
- Tuesday dispatch-order regression (test_real_session_fixtures.py) passes without modification

## Out of scope

- No dispatch reordering or new tool-result types
- No runtime validation changes
- No export engine changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified exit code behavior in export command documentation. Exit codes 0/1/2 now explicitly apply only to bulk exports; single-session exports may return different exit codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/claude-code-chat-browser/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->