### PR TITLE
chore: remove export_count legacy alias from export state API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated since policy PR; bundled SPA updated in same release)
+- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60 / [deprecation policy](docs/deprecation-policy.md); bundled SPA updated in same release)
 
 [Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/f70505982d435f8b1f754cb18c0c9f65609f11b4...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - README notes that the server enforces the debug + host safety rule at startup
 
-### Deprecated
+### Removed
 
-- `export_count` on `GET /api/export/state` (documented only; still returned). Use `last_export_session_count`. Removal planned in a follow-up release per [deprecation policy](docs/deprecation-policy.md).
+- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated since policy PR; bundled SPA updated in same release)
 
 [Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/f70505982d435f8b1f754cb18c0c9f65609f11b4...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
-- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60 / [deprecation policy](docs/deprecation-policy.md); bundled SPA updated in same release)
+- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60; removed before first `v0.1.0` tag per [deprecation policy](docs/deprecation-policy.md) bundled SPA path; SPA updated in same `[Unreleased]` cut)
 
 [Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/f70505982d435f8b1f754cb18c0c9f65609f11b4...HEAD

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -69,7 +69,6 @@ def get_export_state() -> FlaskReturn:
             "last_export_time": state.get("lastExportTime"),
             # Sessions exported in the last completed bulk export (not a lifetime total).
             "last_export_session_count": n,
-            "export_count": n,
         }
     )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -326,13 +326,11 @@ Read-only snapshot of bulk-export state persisted under `~/.claude-code-chat-bro
 |-------|------|-----------|-------------|
 | `last_export_time` | string \| null | stable | ISO timestamp of last completed bulk export |
 | `last_export_session_count` | integer | stable | Sessions in last bulk export run |
-| `export_count` | integer | deprecated | Legacy alias of `last_export_session_count`; prefer `last_export_session_count` in new code (still returned for SPA compatibility; removal per [deprecation-policy.md](deprecation-policy.md)) |
 
 ```json
 {
   "last_export_time": "2026-05-20T18:42:11.123456",
-  "last_export_session_count": 17,
-  "export_count": 17
+  "last_export_session_count": 17
 }
 ```
 

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -27,11 +27,17 @@ A deprecated field may be removed when:
 
 For fields actively read by the bundled SPA (which does not track an external API version), removal happens no earlier than **two tagged releases** after the release that documented the deprecation in CHANGELOG (for example, deprecated in `0.1.0`, removable from `0.3.0` at earliest when versions advance `0.1.0` → `0.2.0` → `0.3.0`), and no earlier than **14 calendar days** after that deprecation announcement.
 
-## Example (in progress)
+### Bundled SPA + pre-first-tag (path B)
 
-| Field | Endpoint | Status | Replacement |
-|-------|----------|--------|-------------|
-| `export_count` | `GET /api/export/state` | deprecated | `last_export_session_count` |
+Until the first git tag ships (for example while `app.__version__` is `0.1.0.dev0`), the CHANGELOG `[Unreleased]` section is the source of truth — see [Versioning](#versioning) below. The bundled SPA is deployed from the same repo and commit as the API; it does not consume a separately versioned HTTP contract.
+
+For fields **only read by the bundled SPA** (no external integrators on a tagged API yet), an atomic PR that (1) stops reading the field in `static/js/*.js` and (2) removes it from the JSON response is acceptable **before** the first tag, provided deprecation was announced in CHANGELOG and api-reference (PR #60) and removal is recorded under `[Unreleased]`. External integrators who pin a **tagged** release must follow the two-release + 14-day rule above.
+
+## Example (completed — pre-first-tag)
+
+| Field | Endpoint | Status | Replacement | Notes |
+|-------|----------|--------|-------------|-------|
+| `export_count` | `GET /api/export/state` | removed | `last_export_session_count` | Deprecated in PR #60 (`[Unreleased]`); removed in bundled SPA+API PR before first `v0.1.0` tag |
 
 ## Versioning
 

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -61,7 +61,7 @@ export async function showProjects() {
                     const d = new Date(exportState.last_export_time);
                     if (!isNaN(d.getTime())) {
                         hasPreviousExport = true;
-                        const sessionCount = Math.max(0, parseInt(exportState.last_export_session_count ?? exportState.export_count ?? 0, 10) || 0);
+                        const sessionCount = Math.max(0, parseInt(exportState.last_export_session_count ?? 0, 10) || 0);
                         lastExportHtml = `<p class="text-muted text-sm">Last export: ${d.toLocaleString()} (${sessionCount} sessions in last export)</p>`;
                     }
                 }

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -71,6 +71,7 @@ def test_export_state_defaults(client_empty):
     assert resp.status_code == 200
     body = resp.get_json()
     assert "last_export_session_count" in body
+    assert "export_count" not in body
 
 
 def test_bulk_export_empty_projects_returns_422(client_empty):

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -70,7 +70,7 @@ def test_export_state_defaults(client_empty):
     resp = client_empty.get("/api/export/state")
     assert resp.status_code == 200
     body = resp.get_json()
-    assert "export_count" in body
+    assert "last_export_session_count" in body
 
 
 def test_bulk_export_empty_projects_returns_422(client_empty):

--- a/tests/test_export_api_bulk.py
+++ b/tests/test_export_api_bulk.py
@@ -86,3 +86,4 @@ def test_export_state_json_fields(isolated_state):
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["last_export_session_count"] == 5
+    assert "export_count" not in body

--- a/tests/test_export_api_bulk.py
+++ b/tests/test_export_api_bulk.py
@@ -86,4 +86,3 @@ def test_export_state_json_fields(isolated_state):
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["last_export_session_count"] == 5
-    assert body["export_count"] == 5


### PR DESCRIPTION
Closes #63 
## Summary

- Removes duplicate `export_count` field from `GET /api/export/state`; SPA reads `last_export_session_count` only
- Updates `docs/api-reference.md` and records removal under `[Unreleased]` in `CHANGELOG.md`
- Aligns tests in `test_api_routes.py` and `test_export_api_bulk.py` with the canonical response shape

Closes Chen W1 #4

## Test plan

- [x] `python -m pytest tests/test_api_routes.py tests/test_export_api_bulk.py -q`
- [x] `python -m pytest -q`
- [x] `npm test`
- [ ] CI green on Ubuntu + Windows
- [ ] Manual: `curl -s http://127.0.0.1:5000/api/export/state` returns no `export_count` key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed export_count from GET /api/export/state response; use last_export_session_count and last_export_time instead.

* **Documentation**
  * Updated API reference and changelog; removal recorded under Unreleased.
  * Clarified deprecation policy for removing SPA-only fields before the first tag.

* **Bug Fixes**
  * UI treats missing/invalid last_export_session_count as 0.

* **Tests**
  * Updated tests to expect last_export_session_count and omit export_count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->