### PR TITLE
feat: add ruff and pip-audit CI gates, fix style violations, and add …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Ruff
         run: ruff check .
 
+      - name: Ruff format check
+        run: ruff format --check .
+
       - name: pip-audit
         run: pip-audit -r requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,37 @@ jobs:
           assert client.get("/").status_code == 200
           PY
 
+  lint-and-audit:
+    name: ruff + pip-audit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: pip-audit
+        run: pip-audit -r requirements.txt
+
   pytest:
     name: pytest (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for considering a patch. This repo is a small Flask app plus a hash-route
 - **Python 3.12** (matches CI)
 - **Node 20+** (only if you change `static/js/` or run frontend unit tests)
 
-CI runs **`pytest`**, **integration tests**, and **Vitest** on **ubuntu-latest** and **windows-latest** (Python 3.12, Node 20). Type-check (`mypy`) and production install smoke run on Ubuntu only.
+CI runs **`ruff check`**, **`ruff format --check`**, **`pip-audit`**, **`pytest`**, **integration tests**, and **Vitest** on **ubuntu-latest** and **windows-latest** (Python 3.12, Node 20). Type-check (`mypy`) and production install smoke run on Ubuntu only.
 
 ### Bootstrap (Windows PowerShell)
 
@@ -58,6 +58,9 @@ When changing JSON response shapes, update the API reference stability column an
 ### Python
 
 ```bash
+ruff check .                           # lint (E, F, W, I) — same gate as CI
+ruff format --check .                  # formatting gate; run `ruff format .` to fix
+pip-audit -r requirements.txt        # production dependency audit (CI gate)
 pytest -q                              # full suite + coverage (see pyproject.toml)
 pytest tests/test_api_integration.py -v
 pytest tests/test_search.py -v
@@ -85,7 +88,8 @@ npm run test:coverage   # optional
 | **Exception leakage** | `5xx` bodies are generic messages only. Log full tracebacks with `current_app.logger.exception(...)`. Never put `str(e)` or class names in HTTP JSON (issue #25). |
 | **Path safety** | Use `safe_join()` from `utils/session_path.py` for any path built from URL segments. |
 | **Imports** | stdlib → third-party → local, blank line between groups. |
-| **Line length** | ~100 characters; no enforced formatter yet. |
+| **Lint / format** | `ruff check .` and `ruff format --check .` (CI gates). Config in `pyproject.toml`; run `ruff format .` to apply formatting locally. |
+| **Line length** | 100 characters (`line-length` in `pyproject.toml`). |
 
 ## Tests required for common changes
 
@@ -105,9 +109,10 @@ npm run test:coverage   # optional
 - Branch names: `feat/<topic>`, `fix/<topic>`, `test/<topic>`, `chore/<topic>`, `docs/<topic>`.
 - One logical change per PR when possible.
 - PR checklist:
+  - [ ] `ruff check .` and `ruff format --check .` green locally
   - [ ] `pytest -q` green locally
   - [ ] `npm test` green if JS changed
-  - [ ] CI jobs green (`pytest`, `integration-tests`, `js-tests` on Ubuntu + Windows; `mypy`, `prod-install-smoke` on Ubuntu)
+  - [ ] CI jobs green (`lint-and-audit`, `pytest`, `integration-tests`, `js-tests` on Ubuntu + Windows; `mypy`, `prod-install-smoke` on Ubuntu)
   - [ ] PR description includes a **Test plan** section
   - [ ] API changes update [`docs/api-reference.md`](docs/api-reference.md) if behavior or errors change
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ npm ci && npm test   # only if you changed static/js/
 
 ## Continuous integration
 
-Every push and pull request runs **`ruff`**, **`pip-audit`**, **`pytest`**, **mypy**, **API integration tests**, and **vitest** on **Ubuntu and Windows** (Python 3.12, Node 20) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A separate job verifies that `pip install -r requirements.txt` (production-only) is sufficient to import and boot the app.
+Every push and pull request runs **`ruff check`**, **`ruff format --check`**, **`pip-audit`**, **`pytest`**, **mypy**, **API integration tests**, and **vitest** on **Ubuntu and Windows** (Python 3.12, Node 20) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A separate job verifies that `pip install -r requirements.txt` (production-only) is sufficient to import and boot the app.
 
 ## Exported Markdown Format
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ REST endpoints for projects, sessions, search, and export are documented in **[`
 
 JSON error responses include a machine-readable `"code"` (stable `UPPER_SNAKE_CASE`) and a human-readable `"error"` message. See the [error code catalog](docs/api-reference.md#error-code-catalog) for the full table.
 
+- **Security policy** — see [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulnerabilities privately
+
 ### CLI Export
 - Standalone script to export all sessions to Markdown with YAML frontmatter
 - Rich Markdown: token usage, tool calls, thinking blocks, model info, timestamps
@@ -155,7 +157,7 @@ npm ci && npm test   # only if you changed static/js/
 
 ## Continuous integration
 
-Every push and pull request runs **`pytest`**, **API integration tests**, and **vitest** on **Ubuntu** (Python 3.12, Node 20) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A separate job verifies that `pip install -r requirements.txt` (production-only) is sufficient to import and boot the app.
+Every push and pull request runs **`ruff`**, **`pip-audit`**, **`pytest`**, **mypy**, **API integration tests**, and **vitest** on **Ubuntu and Windows** (Python 3.12, Node 20) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A separate job verifies that `pip install -r requirements.txt` (production-only) is sufficient to import and boot the app.
 
 ## Exported Markdown Format
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+This project is pre-release. Security fixes are applied to the **latest `master` branch only** (currently `0.1.0.dev0`).
+
+| Version        | Supported |
+| -------------- | --------- |
+| latest `master`| Yes       |
+| older commits  | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/cppalliance/claude-code-chat-browser/security/advisories/new). Private vulnerability reporting must be enabled on the repository (Settings → Security → Private vulnerability reporting). If you cannot use that form, contact the repository maintainers through an existing private channel.
+
+## Response Timeline
+
+| Stage | Target |
+| ----- | ------ |
+| Acknowledgment | Within **72 hours** of a valid report |
+| Initial assessment | Within **7 days** |
+| Fix for confirmed issues | Target **14 days** for issues affecting the default local-only deployment |
+
+Timelines may extend for complex issues; we will keep reporters informed.
+
+## Scope
+
+### In scope
+
+Security issues in this repository that affect users of the default local setup:
+
+- **Path traversal** — session and export paths resolved via `safe_join` in `utils/session_path.py`
+- **Cross-site scripting (XSS)** — rendered session HTML in `static/js/` (mitigated by DOMPurify + SRI in `static/index.html`)
+- **Export integrity** — bulk zip and per-session export in `api/export_api.py` and `utils/export_engine.py`
+- **Local file boundaries** — read-only access to `~/.claude/projects/`; writes limited to export output and app state
+- **Debug-mode exposure** — Flask/Werkzeug debugger when `--debug` is combined with a non-loopback `--host` (blocked at startup in `app.py`)
+- **Information disclosure** — API error responses scrub internal exception details (see `api/error_codes.py`)
+
+### Out of scope
+
+- **Intentional network-facing deployment** — this tool is designed for local browsing on loopback; exposing it on untrusted networks is not a supported configuration
+- **Upstream Claude Code JSONL format bugs** — malformed or hostile data from Claude Code itself (we harden parsing but do not guarantee full isolation from arbitrary JSONL)
+- **Third-party CDN availability** — DOMPurify is loaded from cdnjs with SRI; CDN compromise is an infrastructure concern outside this repo
+
+## Existing Controls (reference)
+
+| Control | Location |
+| ------- | -------- |
+| Path guard (`safe_join`) | `utils/session_path.py` |
+| HTML sanitization (DOMPurify) | `static/js/shared/markdown.js`, `static/index.html` |
+| Error response scrubbing | `api/error_codes.py`, session card handling in `api/projects.py` |
+| Debug + non-loopback host guard | `app.py` (`validate_startup_cli`) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,11 @@ This project is pre-release. Security fixes are applied to the **latest `master`
 
 **Please do not open public GitHub issues for security vulnerabilities.**
 
-Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/cppalliance/claude-code-chat-browser/security/advisories/new). Private vulnerability reporting must be enabled on the repository (Settings → Security → Private vulnerability reporting). If you cannot use that form, contact the repository maintainers through an existing private channel.
+**Primary path (always works):** Contact a [repository maintainer](https://github.com/cppalliance/claude-code-chat-browser/graphs/contributors) through a private channel you already use with the project (for example a direct message or private email). Include steps to reproduce, affected version/commit, and impact.
+
+**GitHub Security Advisories (when enabled):** Once **Private vulnerability reporting** is turned on for this repository (Settings → Security → Private vulnerability reporting), external researchers may use the [private advisory form](https://github.com/cppalliance/claude-code-chat-browser/security/advisories/new). If that link returns 404 or the form is unavailable, use the primary path above — the advisory URL only works when the setting is enabled.
+
+**Repository admins:** Enable private vulnerability reporting before merge if you want the advisory form to be the default reporter path; until then, maintainers should treat the primary path as authoritative.
 
 ## Response Timeline
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This project is pre-release. Security fixes are applied to the **latest `master`
 
 | Version        | Supported |
 | -------------- | --------- |
-| latest `master`| Yes       |
+| latest `master` | Yes       |
 | older commits  | No        |
 
 ## Reporting a Vulnerability

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -1,7 +1,6 @@
 """Export endpoints -- bulk zip download and single-session md/json."""
 
 import io
-import json
 import os
 import zipfile
 from datetime import datetime
@@ -12,20 +11,21 @@ from flask import Blueprint, current_app, request, send_file
 from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from models.export import ExportStateDict
+from utils.exclusion_rules import is_session_excluded
+from utils.export_engine import EXPORT_ERRORS as _EXPORT_ERRORS
+from utils.export_engine import ZipSink, run_bulk_export
 from utils.export_state_store import (
     EXPORT_STATE_FILE,
     atomic_write_export_state,
     export_state_lock,
     load_export_state_from_disk,
 )
-from utils.session_path import get_claude_projects_dir, list_projects
-from utils.jsonl_parser import parse_session
-from utils.exclusion_rules import is_session_excluded
-from utils.session_stats import compute_stats
-from utils.md_exporter import session_to_markdown
 from utils.json_exporter import session_to_json
+from utils.jsonl_parser import parse_session
+from utils.md_exporter import session_to_markdown
+from utils.session_path import get_claude_projects_dir, list_projects
+from utils.session_stats import compute_stats
 from utils.slugify import slugify
-from utils.export_engine import EXPORT_ERRORS as _EXPORT_ERRORS, ZipSink, run_bulk_export
 
 export_bp = Blueprint("export", __name__)
 

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -12,8 +12,7 @@ from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from models.export import ExportStateDict
 from utils.exclusion_rules import is_session_excluded
-from utils.export_engine import EXPORT_ERRORS as _EXPORT_ERRORS
-from utils.export_engine import ZipSink, run_bulk_export
+from utils.export_engine import EXPORT_ERRORS as _EXPORT_ERRORS, ZipSink, run_bulk_export
 from utils.export_state_store import (
     EXPORT_STATE_FILE,
     atomic_write_export_state,
@@ -94,10 +93,7 @@ def bulk_export() -> FlaskReturn:
             since=since,
         )
 
-    base = (
-        current_app.config.get("CLAUDE_PROJECTS_DIR")
-        or get_claude_projects_dir()
-    )
+    base = current_app.config.get("CLAUDE_PROJECTS_DIR") or get_claude_projects_dir()
     projects = list_projects(base)
     rules = current_app.config.get("EXCLUSION_RULES") or []
 
@@ -109,9 +105,7 @@ def bulk_export() -> FlaskReturn:
     buf = io.BytesIO()
 
     def _on_export_error(sid: str, exc: Exception) -> None:
-        current_app.logger.warning(
-            "Failed to export %s: %s", sid[:10], exc
-        )
+        current_app.logger.warning("Failed to export %s: %s", sid[:10], exc)
 
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         result = run_bulk_export(
@@ -163,10 +157,7 @@ def bulk_export() -> FlaskReturn:
 def export_session(project_name: str, session_id: str) -> FlaskReturn:
     from utils.session_path import safe_join
 
-    base = (
-        current_app.config.get("CLAUDE_PROJECTS_DIR")
-        or get_claude_projects_dir()
-    )
+    base = current_app.config.get("CLAUDE_PROJECTS_DIR") or get_claude_projects_dir()
     try:
         filepath = safe_join(base, project_name, f"{session_id}.jsonl")
     except ValueError:
@@ -183,9 +174,7 @@ def export_session(project_name: str, session_id: str) -> FlaskReturn:
     try:
         session = parse_session(filepath)
     except _EXPORT_ERRORS:
-        current_app.logger.exception(
-            "Failed to parse session %s for export", session_id
-        )
+        current_app.logger.exception("Failed to parse session %s for export", session_id)
         return error_response(
             ErrorCode.PARSE_ERROR,
             "Failed to parse session",
@@ -203,9 +192,7 @@ def export_session(project_name: str, session_id: str) -> FlaskReturn:
     try:
         stats = compute_stats(session)
     except _EXPORT_ERRORS:
-        current_app.logger.exception(
-            "Failed to compute stats for export %s", session_id
-        )
+        current_app.logger.exception("Failed to compute stats for export %s", session_id)
         return error_response(
             ErrorCode.INTERNAL_ERROR,
             "Failed to compute session stats",

--- a/api/export_api.py
+++ b/api/export_api.py
@@ -22,7 +22,7 @@ from utils.export_state_store import (
 from utils.json_exporter import session_to_json
 from utils.jsonl_parser import parse_session
 from utils.md_exporter import session_to_markdown
-from utils.session_path import get_claude_projects_dir, list_projects
+from utils.session_path import get_claude_projects_dir, list_projects, safe_join
 from utils.session_stats import compute_stats
 from utils.slugify import slugify
 
@@ -155,8 +155,6 @@ def bulk_export() -> FlaskReturn:
 
 @export_bp.route("/api/export/session/<path:project_name>/<session_id>")
 def export_session(project_name: str, session_id: str) -> FlaskReturn:
-    from utils.session_path import safe_join
-
     base = current_app.config.get("CLAUDE_PROJECTS_DIR") or get_claude_projects_dir()
     try:
         filepath = safe_join(base, project_name, f"{session_id}.jsonl")

--- a/api/projects.py
+++ b/api/projects.py
@@ -2,12 +2,12 @@
 
 from flask import Blueprint, current_app
 
-from api._flask_types import FlaskReturn, json_error, json_response
+from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from models.project import ProjectSessionRowDict, SessionListItemDict
 from models.session import SessionDict
-from utils.session_path import get_claude_projects_dir, list_projects, list_sessions, safe_join
 from utils.exclusion_rules import is_session_excluded
+from utils.session_path import get_claude_projects_dir, list_projects, list_sessions, safe_join
 
 projects_bp = Blueprint("projects", __name__)
 

--- a/api/projects.py
+++ b/api/projects.py
@@ -49,6 +49,7 @@ def get_projects() -> FlaskReturn:
     # so the landing page matches what the workspace page shows.
     # Uses quick_session_info() which peeks at files without full parsing.
     from utils.jsonl_parser import quick_session_info
+
     for project in projects:
         sessions = list_sessions(project["path"])
         titled_count = 0
@@ -81,6 +82,7 @@ def get_project_sessions(project_name: str) -> FlaskReturn:
     sessions = list_sessions(project_dir)
     # Add summary preview for each session
     from utils.jsonl_parser import parse_session
+
     rules = current_app.config.get("EXCLUSION_RULES") or []
     result: list[ProjectSessionRowDict] = []
     for s in sessions:

--- a/api/search.py
+++ b/api/search.py
@@ -1,15 +1,14 @@
 """Search endpoint. Brute-force substring match across all sessions."""
 
-import os
 
 from flask import Blueprint, current_app, request
 
 from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from models.search import SearchHitDict
-from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
-from utils.jsonl_parser import parse_session
 from utils.exclusion_rules import is_session_excluded
+from utils.jsonl_parser import parse_session
+from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
 
 search_bp = Blueprint("search", __name__)
 

--- a/api/search.py
+++ b/api/search.py
@@ -1,6 +1,5 @@
 """Search endpoint. Brute-force substring match across all sessions."""
 
-
 from flask import Blueprint, current_app, request
 
 from api._flask_types import FlaskReturn, json_response
@@ -70,14 +69,16 @@ def search() -> FlaskReturn:
                     end = min(len(text), idx + len(query) + 80)
                     snippet = text[start:end]
 
-                    results.append({
-                        "project": project["name"],
-                        "session_id": session["session_id"],
-                        "title": session["title"],
-                        "role": msg["role"],
-                        "timestamp": msg.get("timestamp"),
-                        "snippet": snippet,
-                    })
+                    results.append(
+                        {
+                            "project": project["name"],
+                            "session_id": session["session_id"],
+                            "title": session["title"],
+                            "role": msg["role"],
+                            "timestamp": msg.get("timestamp"),
+                            "snippet": snippet,
+                        }
+                    )
                     if len(results) >= max_results:
                         break
 

--- a/api/sessions.py
+++ b/api/sessions.py
@@ -89,14 +89,6 @@ def get_session_stats(project_name: str, session_id: str) -> FlaskReturn:
             500,
         )
 
-    rules = current_app.config.get("EXCLUSION_RULES") or []
-    if is_session_excluded(rules, session, project_name):
-        return error_response(
-            ErrorCode.SESSION_NOT_FOUND,
-            "Session not found",
-            404,
-        )
-
     try:
         stats = compute_stats(session)
         return json_response(stats)

--- a/api/sessions.py
+++ b/api/sessions.py
@@ -7,10 +7,10 @@ from flask import Blueprint, current_app
 
 from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
-from utils.session_path import get_claude_projects_dir, safe_join
-from utils.jsonl_parser import parse_session
-from utils.session_stats import compute_stats
 from utils.exclusion_rules import is_session_excluded
+from utils.jsonl_parser import parse_session
+from utils.session_path import get_claude_projects_dir, safe_join
+from utils.session_stats import compute_stats
 
 sessions_bp = Blueprint("sessions", __name__)
 

--- a/app.py
+++ b/app.py
@@ -106,11 +106,12 @@ def build_cli_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--base-dir", default=None, help="Override Claude projects dir")
     parser.add_argument(
-        "--exclude-rules", "-e",
+        "--exclude-rules",
+        "-e",
         default=None,
         metavar="PATH",
         help="Path to exclusion rules file (sensitive sessions are omitted). "
-             "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
+        "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
     )
     return parser
 

--- a/app.py
+++ b/app.py
@@ -3,16 +3,15 @@
 __version__ = "0.1.0.dev0"
 
 import argparse
-import os
 import sys
 
 from flask import Flask
 
-from api.projects import projects_bp
-from api.sessions import sessions_bp
-from api.search import search_bp
 from api.export_api import export_bp
-from utils.exclusion_rules import resolve_exclusion_rules_path, load_rules
+from api.projects import projects_bp
+from api.search import search_bp
+from api.sessions import sessions_bp
+from utils.exclusion_rules import load_rules, resolve_exclusion_rules_path
 
 
 def _normalize_bind_host(host: str) -> str:
@@ -100,7 +99,10 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "--debug",
         action="store_true",
         default=False,
-        help="Enable Flask/Werkzeug debug mode (never use with --host 0.0.0.0 on untrusted networks).",
+        help=(
+            "Enable Flask/Werkzeug debug mode "
+            "(never use with --host 0.0.0.0 on untrusted networks)."
+        ),
     )
     parser.add_argument("--base-dir", default=None, help="Override Claude projects dir")
     parser.add_argument(

--- a/models/export.py
+++ b/models/export.py
@@ -1,6 +1,6 @@
 """Export state file shapes."""
 
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 
 
 class ExportStateDict(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.ruff.lint.per-file-ignores]
 # CLI bootstrap: sys.path must be set before local imports.
 "scripts/export.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,16 @@ omit = [
 [tool.coverage.report]
 fail_under = 60
 include = ["api/*", "utils/*"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+# CLI bootstrap: sys.path must be set before local imports.
+"scripts/export.py" = ["E402"]
+# Tests mirror the same path bootstrap before importing app/utils.
+"tests/*.py" = ["E402"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ pytest==9.0.2
 mypy==1.15.0
 types-Flask==1.1.6
 pytest-cov>=5.0
+ruff>=0.9.0
+pip-audit>=2.7.0

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -31,13 +31,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(SCRIPT_DIR)
 sys.path.insert(0, REPO_ROOT)
 
-from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
-from utils.jsonl_parser import parse_session
-from utils.session_stats import compute_stats, format_duration
-from utils.md_exporter import session_to_markdown
-from utils.json_exporter import session_to_json
-from utils.exclusion_rules import resolve_exclusion_rules_path, load_rules
-from utils.slugify import slugify
+from utils.exclusion_rules import load_rules, resolve_exclusion_rules_path
 from utils.export_engine import (
     BulkExportResult,
     ExportFormat,
@@ -52,6 +46,12 @@ from utils.export_state_store import (
     export_state_lock,
     load_export_state_from_disk,
 )
+from utils.json_exporter import session_to_json
+from utils.jsonl_parser import parse_session
+from utils.md_exporter import session_to_markdown
+from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
+from utils.session_stats import compute_stats, format_duration
+from utils.slugify import slugify
 
 STATE_DIR = os.path.join(os.path.expanduser("~"), ".claude-code-chat-browser")
 STATE_FILE = os.path.join(STATE_DIR, "export_state.json")
@@ -364,7 +364,11 @@ def _aggregate_stats(base_dir: str, project_filter: str, fmt: str):
                     totals["total_cost"] += cost
                     totals["has_cost"] = True
             except Exception as e:
-                print(f"  Warning: failed to parse {s['id'][:10]} in {project['name']}: {e}", file=sys.stderr)
+                print(
+                    f"  Warning: failed to parse {s['id'][:10]} "
+                    f"in {project['name']}: {e}",
+                    file=sys.stderr,
+                )
                 continue
 
     if fmt == "json":
@@ -379,9 +383,15 @@ def _aggregate_stats(base_dir: str, project_filter: str, fmt: str):
     print(f"  Projects:     {totals['projects']}")
     print(f"  Sessions:     {totals['sessions']}")
     print(f"  Models:       {', '.join(sorted(totals['models'])) or 'none'}")
-    print(f"  Total tokens: {total_tokens:,} (input: {totals['input_tokens']:,} / output: {totals['output_tokens']:,})")
+    print(
+        f"  Total tokens: {total_tokens:,} "
+        f"(input: {totals['input_tokens']:,} / output: {totals['output_tokens']:,})"
+    )
     if totals["cache_read_tokens"]:
-        print(f"  Cache:        read: {totals['cache_read_tokens']:,} / creation: {totals['cache_creation_tokens']:,}")
+        print(
+            f"  Cache:        read: {totals['cache_read_tokens']:,} / "
+            f"creation: {totals['cache_creation_tokens']:,}"
+        )
     print(f"  Tool calls:   {totals['tool_calls']:,}")
     if totals["tool_counts"]:
         breakdown = ", ".join(
@@ -598,8 +608,15 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Override Claude Code projects directory")
     parser.add_argument("--project", default=None,
                         help="Filter by project (substring on list display name or dir name)")
-    parser.add_argument("--since", choices=["all", "last", "incremental"], default=None,
-                        help="'last' = latest UTC calendar day; 'incremental' = new since last export (mtime)")
+    parser.add_argument(
+        "--since",
+        choices=["all", "last", "incremental"],
+        default=None,
+        help=(
+            "'last' = latest UTC calendar day; "
+            "'incremental' = new since last export (mtime)"
+        ),
+    )
     parser.add_argument("--out", default=None,
                         help="Output directory (default: current dir)")
     parser.add_argument("--no-zip", action="store_true", default=False,
@@ -732,4 +749,3 @@ def _die(msg: str):
 
 if __name__ == "__main__":
     main()
- 

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -83,16 +83,10 @@ def _zip_export_basename(
     if project_filter:
         if len(projects) == 1:
             p0 = projects[0]
-            parts.append(
-                slugify(p0.get("display_name") or p0["name"], default="project")
-            )
+            parts.append(slugify(p0.get("display_name") or p0["name"], default="project"))
         else:
-            parts.append(
-                f"{slugify(project_filter, default='project')}-n{len(projects)}"
-            )
-    if since == "last" and latest_day is not None and isinstance(
-        latest_day, date
-    ):
+            parts.append(f"{slugify(project_filter, default='project')}-n{len(projects)}")
+    if since == "last" and latest_day is not None and isinstance(latest_day, date):
         parts.append(f"last-{latest_day.strftime('%m-%d')}")
     if parts:
         return f"claude-code-export-{'-'.join(parts)}-{date_tag}.zip"
@@ -114,10 +108,15 @@ def _prefixed_export_option_overrides(argv: list[str]) -> dict[str, object]:
     i = 0
     while i < len(pre):
         a = pre[i]
-        if a == "--since" and i + 1 < len(pre) and pre[i + 1] in (
-            "all",
-            "last",
-            "incremental",
+        if (
+            a == "--since"
+            and i + 1 < len(pre)
+            and pre[i + 1]
+            in (
+                "all",
+                "last",
+                "incremental",
+            )
         ):
             opts["since"] = pre[i + 1]
             i += 2
@@ -170,6 +169,7 @@ def main():
         cmd_stats(args)
     else:
         cmd_export(args)
+
 
 def cmd_list(args):
     """Print a table of projects, or drill into one project's sessions."""
@@ -276,9 +276,7 @@ def _session_stats(session_id: str, base_dir: str, fmt: str):
     print(f"  Tool calls: {meta['total_tool_calls']}")
     if meta["tool_call_counts"]:
         breakdown = ", ".join(
-            f"{t}: {c}" for t, c in sorted(
-                meta["tool_call_counts"].items(), key=lambda x: -x[1]
-            )
+            f"{t}: {c}" for t, c in sorted(meta["tool_call_counts"].items(), key=lambda x: -x[1])
         )
         print(f"              {breakdown}")
     if meta.get("stop_reasons"):
@@ -365,8 +363,7 @@ def _aggregate_stats(base_dir: str, project_filter: str, fmt: str):
                     totals["has_cost"] = True
             except Exception as e:
                 print(
-                    f"  Warning: failed to parse {s['id'][:10]} "
-                    f"in {project['name']}: {e}",
+                    f"  Warning: failed to parse {s['id'][:10]} in {project['name']}: {e}",
                     file=sys.stderr,
                 )
                 continue
@@ -395,9 +392,7 @@ def _aggregate_stats(base_dir: str, project_filter: str, fmt: str):
     print(f"  Tool calls:   {totals['tool_calls']:,}")
     if totals["tool_counts"]:
         breakdown = ", ".join(
-            f"{t}: {c}" for t, c in sorted(
-                totals["tool_counts"].items(), key=lambda x: -x[1]
-            )[:10]
+            f"{t}: {c}" for t, c in sorted(totals["tool_counts"].items(), key=lambda x: -x[1])[:10]
         )
         print(f"                {breakdown}")
     print(f"  Files:        {len(totals['files_unique']):,} unique")
@@ -423,9 +418,9 @@ def _exit_bulk_export(result: BulkExportResult) -> None:
     if n > 0 or k > 0:
         dest = sys.stderr if k > 0 else sys.stdout
         print(f"Exported {n} of {m} sessions ({k} failed)", file=dest)
-    if n == 0 and k > 0:   # total failure
+    if n == 0 and k > 0:  # total failure
         sys.exit(1)
-    elif k > 0:             # partial failure
+    elif k > 0:  # partial failure
         sys.exit(2)
 
 
@@ -503,20 +498,14 @@ def cmd_export(args):
             "exporting sessions that overlap that calendar day."
         )
         if export_result.latest_day_match_count == 0:
-            print(
-                f"No sessions overlap {latest_day.isoformat()} (UTC); "
-                "nothing to export."
-            )
+            print(f"No sessions overlap {latest_day.isoformat()} (UTC); nothing to export.")
             _exit_bulk_export(export_result)
             return
     elif since == "incremental":
         skipped_mtime_unchanged = export_result.skipped_mtime_unchanged_count
 
     exported = len(all_exports)
-    print(
-        f"Exporting {exported} file(s) "
-        f"({skipped} skipped, {total_sessions} total)"
-    )
+    print(f"Exporting {exported} file(s) ({skipped} skipped, {total_sessions} total)")
 
     if not all_exports:
         print("Nothing to export.")
@@ -604,79 +593,88 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=__doc__,
     )
     # Global options (for backward compatibility when no subcommand)
-    parser.add_argument("--base-dir", default=None,
-                        help="Override Claude Code projects directory")
-    parser.add_argument("--project", default=None,
-                        help="Filter by project (substring on list display name or dir name)")
+    parser.add_argument("--base-dir", default=None, help="Override Claude Code projects directory")
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="Filter by project (substring on list display name or dir name)",
+    )
     parser.add_argument(
         "--since",
         choices=["all", "last", "incremental"],
         default=None,
-        help=(
-            "'last' = latest UTC calendar day; "
-            "'incremental' = new since last export (mtime)"
-        ),
+        help=("'last' = latest UTC calendar day; 'incremental' = new since last export (mtime)"),
     )
-    parser.add_argument("--out", default=None,
-                        help="Output directory (default: current dir)")
-    parser.add_argument("--no-zip", action="store_true", default=False,
-                        help="Write individual files instead of zip")
-    parser.add_argument("--format", choices=["md", "json", "both"],
-                        default=None, help="Export format (default: md)")
-    parser.add_argument("--session", default=None,
-                        help="Export/stats for single session (UUID prefix)")
+    parser.add_argument("--out", default=None, help="Output directory (default: current dir)")
     parser.add_argument(
-        "--exclude-rules", "-e",
+        "--no-zip", action="store_true", default=False, help="Write individual files instead of zip"
+    )
+    parser.add_argument(
+        "--format", choices=["md", "json", "both"], default=None, help="Export format (default: md)"
+    )
+    parser.add_argument(
+        "--session", default=None, help="Export/stats for single session (UUID prefix)"
+    )
+    parser.add_argument(
+        "--exclude-rules",
+        "-e",
         default=None,
         metavar="PATH",
         dest="exclude_rules",
         help="Path to exclusion rules file (sensitive sessions are omitted). "
-             "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
+        "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
     )
 
     subparsers = parser.add_subparsers(dest="command")
 
     # List subcommand
     list_p = subparsers.add_parser("list", help="List projects and sessions")
-    list_p.add_argument("--project", default=None,
-                        help="Filter/select project (display name or dir name substring)")
-    list_p.add_argument("--base-dir", default=None,
-                        help="Override Claude Code projects directory")
+    list_p.add_argument(
+        "--project", default=None, help="Filter/select project (display name or dir name substring)"
+    )
+    list_p.add_argument("--base-dir", default=None, help="Override Claude Code projects directory")
 
     # Stats subcommand
     stats_p = subparsers.add_parser("stats", help="Show statistics")
-    stats_p.add_argument("--session", default=None,
-                         help="Stats for specific session (UUID prefix)")
-    stats_p.add_argument("--format", choices=["text", "json"], default="text",
-                         help="Output format (default: text)")
-    stats_p.add_argument("--project", default=None,
-                         help="Filter by project (display name or dir name substring)")
-    stats_p.add_argument("--base-dir", default=None,
-                         help="Override Claude Code projects directory")
+    stats_p.add_argument("--session", default=None, help="Stats for specific session (UUID prefix)")
+    stats_p.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format (default: text)"
+    )
+    stats_p.add_argument(
+        "--project", default=None, help="Filter by project (display name or dir name substring)"
+    )
+    stats_p.add_argument("--base-dir", default=None, help="Override Claude Code projects directory")
 
     # Export subcommand (explicit)
     export_p = subparsers.add_parser("export", help="Export sessions")
-    export_p.add_argument("--since", choices=["all", "last", "incremental"], default="all",
-                          help="'last' = latest UTC day; 'incremental' = new since last export")
-    export_p.add_argument("--out", default=None,
-                          help="Output directory (default: current dir)")
-    export_p.add_argument("--no-zip", action="store_true",
-                          help="Write individual files instead of zip")
-    export_p.add_argument("--format", choices=["md", "json", "both"],
-                          default="md", help="Export format (default: md)")
-    export_p.add_argument("--session", default=None,
-                          help="Export single session by UUID prefix")
-    export_p.add_argument("--project", default=None,
-                          help="Filter by project (display name or dir name substring)")
-    export_p.add_argument("--base-dir", default=None,
-                          help="Override Claude Code projects directory")
     export_p.add_argument(
-        "--exclude-rules", "-e",
+        "--since",
+        choices=["all", "last", "incremental"],
+        default="all",
+        help="'last' = latest UTC day; 'incremental' = new since last export",
+    )
+    export_p.add_argument("--out", default=None, help="Output directory (default: current dir)")
+    export_p.add_argument(
+        "--no-zip", action="store_true", help="Write individual files instead of zip"
+    )
+    export_p.add_argument(
+        "--format", choices=["md", "json", "both"], default="md", help="Export format (default: md)"
+    )
+    export_p.add_argument("--session", default=None, help="Export single session by UUID prefix")
+    export_p.add_argument(
+        "--project", default=None, help="Filter by project (display name or dir name substring)"
+    )
+    export_p.add_argument(
+        "--base-dir", default=None, help="Override Claude Code projects directory"
+    )
+    export_p.add_argument(
+        "--exclude-rules",
+        "-e",
         default=None,
         metavar="PATH",
         dest="exclude_rules",
         help="Path to exclusion rules file (sensitive sessions are omitted). "
-             "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
+        "If omitted, uses ~/.claude-code-chat-browser/exclusion-rules.txt if present.",
     )
 
     return parser

--- a/scripts/gen_real_session_fixtures.py
+++ b/scripts/gen_real_session_fixtures.py
@@ -4,6 +4,7 @@
 Each entry includes top-level ``sessionId`` (real Claude Code JSONL shape). The parser
 currently ignores it and uses the filename for ``session_id``.
 """
+
 from __future__ import annotations
 
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,4 @@ def client_empty(tmp_path, export_state_file):
 @pytest.fixture
 def client_thinking(tmp_path, export_state_file):
     """Flask test client with a session containing thinking content blocks."""
-    return _make_test_client(
-        tmp_path, {"session_think001.jsonl": "session_with_thinking.jsonl"}
-    )
+    return _make_test_client(tmp_path, {"session_think001.jsonl": "session_with_thinking.jsonl"})

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -75,9 +75,7 @@ def test_session_detail_includes_thinking_blocks(client_thinking):
     session = resp.get_json()
     assert "messages" in session
     assistant_msgs = [m for m in session["messages"] if m.get("role") == "assistant"]
-    assert any(
-        m.get("thinking") == "Considering options carefully." for m in assistant_msgs
-    )
+    assert any(m.get("thinking") == "Considering options carefully." for m in assistant_msgs)
 
 
 # --- /api/search ---

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -9,9 +9,7 @@ Fixtures (`client`, `client_empty`, `client_thinking`) live in tests/conftest.py
 
 from __future__ import annotations
 
-
 from tests.conftest import assert_error_response as _assert_error_shape
-
 
 # --- /api/projects ---
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
+from app import create_app
 from tests.conftest import assert_error_response
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_index_returns_html(client):
     resp = client.get("/")
     assert resp.status_code == 200
-    assert b"html" in resp.data.lower() or (
-        resp.content_type and "html" in resp.content_type
-    )
+    assert b"html" in resp.data.lower() or (resp.content_type and "html" in resp.content_type)
 
 
 def test_session_stats_happy_path(client):
@@ -23,6 +27,23 @@ def test_session_stats_happy_path(client):
 
 def test_session_stats_not_found(client):
     resp = client.get("/api/sessions/test-project/nonexistent/stats")
+    assert resp.status_code == 404
+    assert_error_response(resp, expected_code="SESSION_NOT_FOUND")
+
+
+def test_session_stats_excluded_session_returns_404(tmp_path, export_state_file):
+    project_dir = tmp_path / "test-project"
+    project_dir.mkdir(parents=True)
+    shutil.copy(FIXTURES / "session_minimal.jsonl", project_dir / "session_abc123.jsonl")
+
+    rules_path = tmp_path / "exclusion-rules.txt"
+    rules_path.write_text("integration fixture\n", encoding="utf-8")
+
+    app = create_app(base_dir=str(tmp_path), exclusion_rules_path=str(rules_path))
+    app.config["TESTING"] = True
+    excluded_client = app.test_client()
+
+    resp = excluded_client.get("/api/sessions/test-project/session_abc123/stats")
     assert resp.status_code == 404
     assert_error_response(resp, expected_code="SESSION_NOT_FOUND")
 
@@ -41,6 +62,7 @@ def test_session_detail_invalid_path(client):
 
 def test_session_detail_parse_failure_returns_500_without_leak(client, monkeypatch):
     """Parser failures must return generic PARSE_ERROR, not exception internals (#25)."""
+
     def _boom(*_args, **_kwargs):
         raise KeyError("internal_secret_field_id")
 
@@ -106,9 +128,7 @@ def test_export_session_markdown_attachment(client):
 
 
 def test_export_session_json_format(client):
-    resp = client.get(
-        "/api/export/session/test-project/session_abc123?format=json"
-    )
+    resp = client.get("/api/export/session/test-project/session_abc123?format=json")
     assert resp.status_code == 200
     assert resp.mimetype == "application/json"
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -114,6 +114,7 @@ def _use_reloader_kwarg_tied_to_debug(call: ast.Call) -> bool:
 # export.py argument tests
 # ---------------------------------------------------------------------------
 
+
 class TestExportParserFlags:
     """Every flag that cursor's export.py exposes must also exist here."""
 
@@ -300,6 +301,7 @@ class TestExportParserFlags:
 # app.py argument tests
 # ---------------------------------------------------------------------------
 
+
 class TestAppArgparse:
     """app.py CLI must expose the same flags as cursor's app.py."""
 
@@ -324,9 +326,7 @@ class TestAppArgparse:
         args = parser.parse_args(["--debug"])
         assert args.debug is True
 
-    @pytest.mark.parametrize(
-        "host", ["127.0.0.1", "localhost", "::1", "[::1]", "127.0.0.2"]
-    )
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "[::1]", "127.0.0.2"])
     def test_is_loopback_host_accepts_loopback(self, host: str) -> None:
         assert is_loopback_host(host)
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -9,12 +9,11 @@ Run:
     pytest tests/test_cli_args.py -v
 """
 
-import ast
-import sys
-import os
-import importlib
 import argparse
-import types
+import ast
+import os
+import sys
+
 import pytest
 
 # Ensure the repo root is on sys.path when tests are run from any directory.
@@ -92,7 +91,11 @@ def _is_sys_platform_ne_win32(node: ast.AST) -> bool:
 
 def _is_debug_and_platform_guard(node: ast.AST) -> bool:
     """True for ``args.debug and (sys.platform != "win32")`` in either operand order."""
-    if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.And) or len(node.values) != 2:
+    if (
+        not isinstance(node, ast.BoolOp)
+        or not isinstance(node.op, ast.And)
+        or len(node.values) != 2
+    ):
         return False
     a, b = node.values
     return (_is_args_debug(a) and _is_sys_platform_ne_win32(b)) or (
@@ -428,10 +431,6 @@ class TestAppArgparse:
 
     def test_app_py_actual_argparse_has_exclude_rules(self):
         """Smoke-test: import app module and verify argparse accepts -e."""
-        result = os.popen(
-            f'{sys.executable} -c "'
-            'import sys, os; sys.path.insert(0, os.path.abspath(\\\".\\\"));"'
-        )
         # Lightweight check: parse the app.py source for the flag definition
         app_path = os.path.join(REPO_ROOT, "app.py")
         with open(app_path, "r", encoding="utf-8") as f:

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -75,13 +75,15 @@ def test_cli_stats_exits_zero(tmp_path):
 
 def test_cli_invalid_since_exits_nonzero(tmp_path):
     base = _seed_base_dir(tmp_path)
-    proc = _run_cli([
-        "export",
-        "--since",
-        "yesterday",
-        "--base-dir",
-        str(base),
-    ])
+    proc = _run_cli(
+        [
+            "export",
+            "--since",
+            "yesterday",
+            "--base-dir",
+            str(base),
+        ]
+    )
     assert proc.returncode != 0
     assert "--since" in proc.stderr
     assert "invalid choice" in proc.stderr.lower()
@@ -91,16 +93,18 @@ def test_cli_invalid_since_exits_nonzero(tmp_path):
 def test_cli_export_creates_output(tmp_path):
     base = _seed_base_dir(tmp_path)
     out_dir = tmp_path / "out"
-    proc = _run_cli([
-        "export",
-        "--base-dir",
-        str(base),
-        "--since",
-        "all",
-        "--no-zip",
-        "--out",
-        str(out_dir),
-    ])
+    proc = _run_cli(
+        [
+            "export",
+            "--base-dir",
+            str(base),
+            "--since",
+            "all",
+            "--no-zip",
+            "--out",
+            str(out_dir),
+        ]
+    )
     assert proc.returncode == 0, proc.stderr
     md_files = list(out_dir.rglob("*.md"))
     assert len(md_files) >= 1

--- a/tests/test_cli_export_exit_codes.py
+++ b/tests/test_cli_export_exit_codes.py
@@ -12,10 +12,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-import scripts.export as export  # noqa: E402
-from tests.test_cli_e2e import _run_cli, _seed_base_dir  # noqa: E402
-from utils.export_engine import BulkExportResult  # noqa: E402
-from utils.jsonl_parser import parse_session  # noqa: E402
+import scripts.export as export
+from tests.test_cli_e2e import _run_cli, _seed_base_dir
+from utils.export_engine import BulkExportResult
+from utils.jsonl_parser import parse_session
 
 _SUMMARY_RE = re.compile(
     r"Exported \d+ of \d+ sessions \(\d+ failed\)",
@@ -44,16 +44,18 @@ def _export_args(tmp_path: Path, base: Path, out_dir: Path) -> types.SimpleNames
 def test_cli_export_clean_exits_zero(tmp_path):
     base = _seed_base_dir(tmp_path)
     out_dir = tmp_path / "out"
-    proc = _run_cli([
-        "export",
-        "--base-dir",
-        str(base),
-        "--since",
-        "all",
-        "--no-zip",
-        "--out",
-        str(out_dir),
-    ])
+    proc = _run_cli(
+        [
+            "export",
+            "--base-dir",
+            str(base),
+            "--since",
+            "all",
+            "--no-zip",
+            "--out",
+            str(out_dir),
+        ]
+    )
     assert proc.returncode == 0, proc.stderr
     assert list(out_dir.rglob("*.md"))
     # Success summary must go to stdout, not stderr
@@ -61,9 +63,7 @@ def test_cli_export_clean_exits_zero(tmp_path):
     assert "Exported 1 of 1 sessions (0 failed)" in proc.stdout
 
 
-def test_cli_export_partial_failure_exits_two(
-    tmp_path, monkeypatch, capsys
-):
+def test_cli_export_partial_failure_exits_two(tmp_path, monkeypatch, capsys):
     """One session exports; a second fails parse (simulated corrupt file)."""
     base = _seed_base_dir(tmp_path)
     project_dir = base / "test-project"
@@ -95,9 +95,7 @@ def test_cli_export_partial_failure_exits_two(
     assert len(list(out_dir.rglob("*.md"))) == 1
 
 
-def test_since_last_early_return_invokes_exit_bulk_export(
-    tmp_path, monkeypatch, capsys
-):
+def test_since_last_early_return_invokes_exit_bulk_export(tmp_path, monkeypatch, capsys):
     """cmd_export --since last must call _exit_bulk_export on early-return paths."""
     exit_calls: list[BulkExportResult] = []
 
@@ -134,9 +132,7 @@ def test_since_last_early_return_invokes_exit_bulk_export(
     assert "Exported" not in captured.err
 
 
-def test_since_last_early_return_exits_one_on_failure(
-    tmp_path, monkeypatch, capsys
-):
+def test_since_last_early_return_exits_one_on_failure(tmp_path, monkeypatch, capsys):
     """Since-last early-return with failure_count>0 must produce real exit code 1."""
     fake_result = BulkExportResult(latest_day=None, failure_count=1)
 

--- a/tests/test_cli_export_exit_codes.py
+++ b/tests/test_cli_export_exit_codes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import sys
 import types

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -34,7 +34,6 @@ from flask import Flask  # noqa: E402
 from api.projects import projects_bp  # noqa: E402
 from api.sessions import sessions_bp  # noqa: E402
 
-
 # Defensive blocklist — any of these substrings appearing in a response body
 # would mean the leak regressed. Includes common Python builtin exception
 # class names plus internal-looking shapes.
@@ -193,7 +192,9 @@ class TestGetProjectsErrorCard:
         )
         _assert_no_class_name_leak(json.dumps(body))
         error_rows = [r for r in body if isinstance(r, dict) and r.get("error")]
-        assert error_rows, "Expected at least one per-session error card from the forced parse failure"
+        assert error_rows, (
+            "Expected at least one per-session error card from the forced parse failure"
+        )
         for row in error_rows:
             assert "error_detail" not in row, (
                 "Per-session error card still includes error_detail (issue #25)"

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -29,10 +29,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from flask import Flask  # noqa: E402
+from flask import Flask
 
-from api.projects import projects_bp  # noqa: E402
-from api.sessions import sessions_bp  # noqa: E402
+from api.projects import projects_bp
+from api.sessions import sessions_bp
 
 # Defensive blocklist — any of these substrings appearing in a response body
 # would mean the leak regressed. Includes common Python builtin exception
@@ -96,8 +96,8 @@ def _write_session(tmp_path, project: str, session_id: str, content: str):
 # /api/sessions/<project>/<id>
 # ---------------------------------------------------------------------------
 
-class TestGetSessionErrorBody:
 
+class TestGetSessionErrorBody:
     def test_500_on_parse_failure_does_not_leak_class_name(self, tmp_path, client, monkeypatch):
         # Force the parser to raise an exception with a class-name + message
         # that WOULD leak through the old f-string interpolation if the fix
@@ -142,8 +142,8 @@ class TestGetSessionErrorBody:
 # /api/sessions/<project>/<id>/stats
 # ---------------------------------------------------------------------------
 
-class TestGetSessionStatsErrorBody:
 
+class TestGetSessionStatsErrorBody:
     def test_500_on_parse_failure_does_not_leak_class_name(self, tmp_path, client, monkeypatch):
         _write_session(tmp_path, "proj", "abc", "{}")
 
@@ -166,8 +166,8 @@ class TestGetSessionStatsErrorBody:
 # /api/projects (per-session card)
 # ---------------------------------------------------------------------------
 
-class TestGetProjectsErrorCard:
 
+class TestGetProjectsErrorCard:
     def test_per_session_error_card_omits_error_detail(self, tmp_path, client, monkeypatch):
         # parse_session is tolerant of malformed lines, so to exercise the
         # except branch deterministically (the one that builds the error
@@ -208,6 +208,7 @@ class TestGetProjectsErrorCard:
 # Source-level guard
 # ---------------------------------------------------------------------------
 
+
 class TestNoExceptionInterpolationInSource:
     """Static guard: any future PR that re-introduces the
     `f"...{type(e).__name__}: {e}..."` pattern in api/ fails this test."""
@@ -220,11 +221,10 @@ class TestNoExceptionInterpolationInSource:
             # contains both `type(e)` or `{e}` AND the word "error".
             offending_patterns = [
                 "type(e).__name__",  # the class-name expose
-                "{e}\"",             # bare {e} ending an f-string
-                "{e},",              # bare {e} in a dict-value f-string
+                '{e}"',  # bare {e} ending an f-string
+                "{e},",  # bare {e} in a dict-value f-string
             ]
             for pat in offending_patterns:
                 assert pat not in src, (
-                    f"{py_file.name} contains forbidden pattern {pat!r} "
-                    f"— see issue #25"
+                    f"{py_file.name} contains forbidden pattern {pat!r} — see issue #25"
                 )

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -21,6 +21,7 @@ Run:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -210,21 +211,29 @@ class TestGetProjectsErrorCard:
 
 
 class TestNoExceptionInterpolationInSource:
-    """Static guard: any future PR that re-introduces the
-    `f"...{type(e).__name__}: {e}..."` pattern in api/ fails this test."""
+    """Static guard: any future PR that re-introduces exception interpolation
+    in api/ response bodies fails this test.
+
+    Patterns caught:
+    - type(e).__name__         — explicit class-name expose
+    - {e}  with any common    — f-string that embeds the exception value directly
+      trailing character       (closing quote, comma, paren, space, closing brace)
+    - {str(e)} / {repr(e)}    — wrapped but still leaks message content
+    """
+
+    _LEAK_RE = re.compile(
+        r"type\(e\)\.__name__"  # explicit class name
+        r"|\{e[\"',)\s}]"  # {e} followed by: quote, comma, paren, space, closing brace
+        r"|\{str\(e\)"  # {str(e)} — still leaks message
+        r"|\{repr\(e\)",  # {repr(e)} — still leaks message
+    )
 
     def test_api_files_dont_interpolate_exception_in_jsonify(self):
         api_dir = REPO_ROOT / "api"
         for py_file in api_dir.glob("*.py"):
             src = py_file.read_text(encoding="utf-8")
-            # Look for the specific footgun: jsonify(...) with f-string that
-            # contains both `type(e)` or `{e}` AND the word "error".
-            offending_patterns = [
-                "type(e).__name__",  # the class-name expose
-                '{e}"',  # bare {e} ending an f-string
-                "{e},",  # bare {e} in a dict-value f-string
-            ]
-            for pat in offending_patterns:
-                assert pat not in src, (
-                    f"{py_file.name} contains forbidden pattern {pat!r} — see issue #25"
-                )
+            m = self._LEAK_RE.search(src)
+            assert m is None, (
+                f"{py_file.name} contains forbidden exception-interpolation pattern "
+                f"{m.group(0)!r} at position {m.start()} — see issue #25"
+            )

--- a/tests/test_exclusion_helpers.py
+++ b/tests/test_exclusion_helpers.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
@@ -29,7 +27,6 @@ from utils.exclusion_rules import (
     load_rules,
     session_text_for_exclusion,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_exclusion_helpers.py
+++ b/tests/test_exclusion_helpers.py
@@ -32,6 +32,7 @@ from utils.exclusion_rules import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _write_rules(tmp_path, *lines: str) -> str:
     """Write rules file and return its path. Tokenized by load_rules."""
     p = tmp_path / "exclusion-rules.txt"
@@ -39,8 +40,9 @@ def _write_rules(tmp_path, *lines: str) -> str:
     return str(p)
 
 
-def _session(*, title: str = "session", models: list[str] | None = None,
-             messages: list[dict] | None = None) -> dict:
+def _session(
+    *, title: str = "session", models: list[str] | None = None, messages: list[dict] | None = None
+) -> dict:
     return {
         "title": title,
         "metadata": {"models_used": models or []},
@@ -52,8 +54,8 @@ def _session(*, title: str = "session", models: list[str] | None = None,
 # session_text_for_exclusion
 # ---------------------------------------------------------------------------
 
-class TestSessionTextForExclusion:
 
+class TestSessionTextForExclusion:
     def test_empty_session(self):
         assert session_text_for_exclusion({}) == ""
 
@@ -72,12 +74,14 @@ class TestSessionTextForExclusion:
         # Regression: this is the inconsistency the consolidation fixed —
         # the helper rejects whitespace-only strings, the previous inline
         # variants didn't. The helper version is now canonical.
-        s = _session(messages=[
-            {"text": "alpha"},
-            {"text": "   "},          # whitespace-only — should be skipped
-            {"text": "\n\t\n"},       # whitespace-only — should be skipped
-            {"text": "beta"},
-        ])
+        s = _session(
+            messages=[
+                {"text": "alpha"},
+                {"text": "   "},  # whitespace-only — should be skipped
+                {"text": "\n\t\n"},  # whitespace-only — should be skipped
+                {"text": "beta"},
+            ]
+        )
         assert session_text_for_exclusion(s) == "alpha\n\nbeta"
 
     def test_skips_non_string_text(self):
@@ -89,8 +93,8 @@ class TestSessionTextForExclusion:
 # is_session_excluded
 # ---------------------------------------------------------------------------
 
-class TestIsSessionExcluded:
 
+class TestIsSessionExcluded:
     def test_returns_false_when_rules_empty(self, tmp_path):
         s = _session(title="anything", messages=[{"text": "anything"}])
         assert is_session_excluded([], s, "any project") is False

--- a/tests/test_export_api_bulk.py
+++ b/tests/test_export_api_bulk.py
@@ -11,9 +11,9 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from flask import Flask  # noqa: E402
+from flask import Flask
 
-from api.export_api import export_bp  # noqa: E402
+from api.export_api import export_bp
 
 
 @pytest.fixture
@@ -71,11 +71,13 @@ def test_bulk_export_empty_returns_422_json(isolated_state, tmp_path):
 
 def test_export_state_json_fields(isolated_state):
     isolated_state.write_text(
-        json.dumps({
-            "lastExportTime": "2026-01-01T12:00:00",
-            "exportedCount": 5,
-            "sessions": {},
-        }),
+        json.dumps(
+            {
+                "lastExportTime": "2026-01-01T12:00:00",
+                "exportedCount": 5,
+                "sessions": {},
+            }
+        ),
         encoding="utf-8",
     )
     app = Flask(__name__)

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -8,8 +8,6 @@ import sys
 import zipfile
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 

--- a/tests/test_export_engine_parity.py
+++ b/tests/test_export_engine_parity.py
@@ -11,17 +11,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from flask import Flask  # noqa: E402
+from flask import Flask
 
-from api.export_api import export_bp  # noqa: E402
-from tests.test_cli_e2e import _run_cli, _seed_base_dir  # noqa: E402
-from utils.export_engine import (  # noqa: E402
+from api.export_api import export_bp
+from tests.test_cli_e2e import _run_cli, _seed_base_dir
+from utils.export_engine import (
     MANIFEST_SHARED_KEYS,
     NoopSink,
     manifest_shared_subset,
     run_bulk_export,
 )
-from utils.session_path import list_projects  # noqa: E402
+from utils.session_path import list_projects
 
 
 def _markdown_from_exports(exports: list[tuple[str, str]]) -> str:
@@ -60,9 +60,7 @@ def test_engine_api_vs_cli_layout_same_markdown_and_manifest(tmp_path: Path) -> 
 
     assert api_result.exported_session_count == 1
     assert cli_result.exported_session_count == 1
-    assert _markdown_from_exports(api_result.exports) == _markdown_from_exports(
-        cli_result.exports
-    )
+    assert _markdown_from_exports(api_result.exports) == _markdown_from_exports(cli_result.exports)
 
     api_core = manifest_shared_subset(api_result.manifest[0])
     cli_core = manifest_shared_subset(cli_result.manifest[0])
@@ -94,16 +92,18 @@ def test_http_post_export_matches_cli_no_zip(tmp_path: Path, monkeypatch) -> Non
     assert len(http_manifest) == 1, f"expected one manifest row, got {len(http_manifest)}"
 
     out_dir = tmp_path / "cli_out"
-    proc = _run_cli([
-        "export",
-        "--base-dir",
-        str(base),
-        "--since",
-        "all",
-        "--no-zip",
-        "--out",
-        str(out_dir),
-    ])
+    proc = _run_cli(
+        [
+            "export",
+            "--base-dir",
+            str(base),
+            "--since",
+            "all",
+            "--no-zip",
+            "--out",
+            str(out_dir),
+        ]
+    )
     assert proc.returncode == 0, proc.stderr
 
     cli_md_files = list(out_dir.rglob("*.md"))

--- a/tests/test_export_exclusion_filtering.py
+++ b/tests/test_export_exclusion_filtering.py
@@ -22,6 +22,7 @@ EXPORT_SCRIPT = REPO_ROOT / "scripts" / "export.py"
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _write_session(project_dir: Path, session_id: str, messages: list[dict]) -> Path:
     """Write a minimal JSONL session file and return its path."""
     path = project_dir / f"{session_id}.jsonl"
@@ -74,10 +75,13 @@ def _run_export(
     cmd = [
         sys.executable,
         str(EXPORT_SCRIPT),
-        "--base-dir", str(base_dir),
-        "--since", "all",
+        "--base-dir",
+        str(base_dir),
+        "--since",
+        "all",
         "--no-zip",
-        "--out", str(out_dir),
+        "--out",
+        str(out_dir),
     ]
     if rules_path:
         cmd += ["--exclude-rules", str(rules_path)]
@@ -98,6 +102,7 @@ def _collect_md(out_dir: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestExclusionRulesFiltering:
     def test_matched_session_is_excluded(self, tmp_path):
@@ -152,11 +157,15 @@ class TestExclusionRulesFiltering:
         cmd = [
             sys.executable,
             str(EXPORT_SCRIPT),
-            "--base-dir", str(tmp_path / "projects"),
-            "--since", "all",
+            "--base-dir",
+            str(tmp_path / "projects"),
+            "--since",
+            "all",
             "--no-zip",
-            "--out", str(out_dir),
-            "-e", str(rules_file),
+            "--out",
+            str(out_dir),
+            "-e",
+            str(rules_file),
         ]
         proc = subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
         assert proc.returncode == 0, proc.stderr
@@ -239,11 +248,15 @@ class TestExclusionRulesFiltering:
             sys.executable,
             str(EXPORT_SCRIPT),
             "export",
-            "--base-dir", str(tmp_path / "projects"),
-            "--since", "all",
+            "--base-dir",
+            str(tmp_path / "projects"),
+            "--since",
+            "all",
             "--no-zip",
-            "--out", str(out_dir),
-            "--exclude-rules", str(rules_file),
+            "--out",
+            str(out_dir),
+            "--exclude-rules",
+            str(rules_file),
         ]
         proc = subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
         assert proc.returncode == 0, proc.stderr
@@ -267,14 +280,13 @@ class TestExclusionRulesFiltering:
         # by running with a custom STATE_DIR via monkeypatching in the same
         # process — we test the _save_state API directly.
         import scripts.export as exp
+
         original_state_file = exp.STATE_FILE
         original_state_dir = exp.STATE_DIR
         exp.STATE_FILE = str(state_dir / "export_state.json")
         exp.STATE_DIR = str(state_dir)
         try:
-            exp._save_state(
-                sessions={sid: 1740000000.0}, count=1, out_dir=str(out_dir)
-            )
+            exp._save_state(sessions={sid: 1740000000.0}, count=1, out_dir=str(out_dir))
             with open(exp.STATE_FILE) as f:
                 state = json.load(f)
             for key in ("lastExportTime", "exportedCount", "exportDir", "sessions"):

--- a/tests/test_export_exclusion_filtering.py
+++ b/tests/test_export_exclusion_filtering.py
@@ -10,13 +10,9 @@ Run:
 """
 
 import json
-import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXPORT_SCRIPT = REPO_ROOT / "scripts" / "export.py"

--- a/tests/test_export_state.py
+++ b/tests/test_export_state.py
@@ -13,17 +13,13 @@ Run:
 import json
 import os
 import sys
-import tempfile
 from datetime import datetime
-
-import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
 # Patch STATE_FILE before importing the module so we don't touch the real one.
 import scripts.export as _export_mod
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_export_state.py
+++ b/tests/test_export_state.py
@@ -25,6 +25,7 @@ import scripts.export as _export_mod
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _tmp_state_file(tmp_path):
     """Return a temporary state file path and patch the module to use it."""
     path = str(tmp_path / "export_state.json")
@@ -36,6 +37,7 @@ def _tmp_state_file(tmp_path):
 # ---------------------------------------------------------------------------
 # _save_state tests
 # ---------------------------------------------------------------------------
+
 
 class TestSaveState:
     def test_writes_last_export_time(self, tmp_path):
@@ -97,6 +99,7 @@ class TestSaveState:
 # ---------------------------------------------------------------------------
 # _load_state tests
 # ---------------------------------------------------------------------------
+
 
 class TestLoadState:
     def test_returns_empty_dict_when_no_file(self, tmp_path):
@@ -165,15 +168,14 @@ class TestLoadState:
 # _save_state → _load_state → since-last filtering integration
 # ---------------------------------------------------------------------------
 
+
 class TestSinceLastFiltering:
     """Verify the since-last flow: save state, reload, new session skipped."""
 
     def test_session_skipped_after_save(self, tmp_path):
         _tmp_state_file(tmp_path)
         mtime = 1740000000.0
-        _export_mod._save_state(
-            sessions={"sess-known": mtime}, count=1, out_dir="/tmp"
-        )
+        _export_mod._save_state(sessions={"sess-known": mtime}, count=1, out_dir="/tmp")
 
         state = _export_mod._load_state()
         last_export = state.get("sessions", {})

--- a/tests/test_export_state_store.py
+++ b/tests/test_export_state_store.py
@@ -30,6 +30,7 @@ def _assert_file_stays_absent(path: Path, timeout: float = 0.5) -> None:
             raise AssertionError(f"{path} appeared while parent still holds the lock")
         time.sleep(0.01)
 
+
 from utils.export_state_store import (
     atomic_write_export_state,
     export_state_lock,
@@ -86,9 +87,7 @@ def test_load_legacy_flat_dict_unchanged_shape(tmp_path: Path):
     assert out == {"sessions": legacy}
 
 
-def test_export_state_lock_windows_branch_uses_msvcrt_when_no_fcntl(
-    monkeypatch, tmp_path: Path
-):
+def test_export_state_lock_windows_branch_uses_msvcrt_when_no_fcntl(monkeypatch, tmp_path: Path):
     """When ``fcntl`` is absent, use ``msvcrt.locking`` (cross-process on Windows)."""
     import utils.export_state_store as mod
 

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -22,7 +22,6 @@ from utils.jsonl_parser import (  # noqa: E402
     quick_session_info,
 )
 
-
 # ---------------------------------------------------------------------------
 # Metadata helpers (match parse_session initialisation)
 # ---------------------------------------------------------------------------
@@ -289,7 +288,8 @@ class TestNormalizeContent:
 
 class TestExtractText:
     def test_text_blocks_joined(self):
-        assert _extract_text([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a\nb"
+        blocks = [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+        assert _extract_text(blocks) == "a\nb"
 
     def test_tool_use_blocks_ignored(self):
         assert _extract_text([{"type": "tool_use", "name": "Read"}]) == ""
@@ -679,10 +679,17 @@ class TestParseSession:
             os.unlink(path)
 
     def test_entry_counts_accumulated(self):
-        path = _write_jsonl([
-            {"type": "assistant", "timestamp": "2026-01-01T00:00:00Z", "message": {"model": "m", "content": [], "usage": {}}},
-            {"type": "user", "timestamp": "2026-01-01T00:01:00Z", "message": {"content": []}},
-        ])
+        assistant_entry = {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"model": "m", "content": [], "usage": {}},
+        }
+        user_entry = {
+            "type": "user",
+            "timestamp": "2026-01-01T00:01:00Z",
+            "message": {"content": []},
+        }
+        path = _write_jsonl([assistant_entry, user_entry])
         try:
             s = parse_session(path)
             assert s["metadata"]["entry_counts"]["assistant"] == 1
@@ -821,7 +828,11 @@ class TestQuickSessionInfo:
             lines.append({
                 "type": "assistant",
                 "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"model": "m", "content": [{"type": "text", "text": "x" * 80}], "usage": {}},
+                "message": {
+                    "model": "m",
+                    "content": [{"type": "text", "text": "x" * 80}],
+                    "usage": {},
+                },
             })
         lines.append({
             "type": "assistant",
@@ -837,9 +848,12 @@ class TestQuickSessionInfo:
             os.unlink(path)
 
     def test_no_user_entries_returns_untitled(self):
-        path = _write_jsonl([
-            {"type": "assistant", "timestamp": "2026-01-01T00:00:00Z", "message": {"model": "m", "content": [], "usage": {}}},
-        ])
+        assistant_only = {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {"model": "m", "content": [], "usage": {}},
+        }
+        path = _write_jsonl([assistant_only])
         try:
             info = quick_session_info(path)
             assert info["title"] == "Untitled Session"

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -7,7 +7,7 @@ import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from utils.jsonl_parser import (  # noqa: E402
+from utils.jsonl_parser import (
     _extract_images,
     _extract_text,
     _infer_title,
@@ -25,6 +25,7 @@ from utils.jsonl_parser import (  # noqa: E402
 # ---------------------------------------------------------------------------
 # Metadata helpers (match parse_session initialisation)
 # ---------------------------------------------------------------------------
+
 
 def _fresh_metadata() -> dict:
     return {
@@ -61,9 +62,7 @@ def _fresh_metadata() -> dict:
 
 
 def _write_jsonl(entries: list) -> str:
-    f = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
-    )
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
     for entry in entries:
         f.write(json.dumps(entry) + "\n")
     f.close()
@@ -73,6 +72,7 @@ def _write_jsonl(entries: list) -> str:
 # ---------------------------------------------------------------------------
 # _parse_tool_result
 # ---------------------------------------------------------------------------
+
 
 class TestParseToolResult:
     def test_bash_with_stdout(self):
@@ -92,13 +92,15 @@ class TestParseToolResult:
         assert r.get("stdout") == ""
 
     def test_bash_with_exit_code_and_interrupted(self):
-        r = _parse_tool_result({
-            "stdout": "",
-            "stderr": "",
-            "exitCode": 130,
-            "interrupted": True,
-            "is_error": True,
-        })
+        r = _parse_tool_result(
+            {
+                "stdout": "",
+                "stderr": "",
+                "exitCode": 130,
+                "interrupted": True,
+                "is_error": True,
+            }
+        )
         assert r["exit_code"] == 130
         assert r["interrupted"] is True
         assert r["is_error"] is True
@@ -109,11 +111,13 @@ class TestParseToolResult:
         assert r["file_path"] == "/a.py"
 
     def test_file_edit_with_old_new_string(self):
-        r = _parse_tool_result({
-            "filePath": "/b.ts",
-            "newString": "y",
-            "replaceAll": True,
-        })
+        r = _parse_tool_result(
+            {
+                "filePath": "/b.ts",
+                "newString": "y",
+                "replaceAll": True,
+            }
+        )
         assert r["result_type"] == "file_edit"
         assert r["replace_all"] is True
 
@@ -123,12 +127,14 @@ class TestParseToolResult:
         assert r["file_path"] == "/c.txt"
 
     def test_glob_result(self):
-        r = _parse_tool_result({
-            "filenames": ["a", "b"],
-            "numFiles": 2,
-            "truncated": False,
-            "durationMs": 12,
-        })
+        r = _parse_tool_result(
+            {
+                "filenames": ["a", "b"],
+                "numFiles": 2,
+                "truncated": False,
+                "durationMs": 12,
+            }
+        )
         assert r["result_type"] == "glob"
         assert r["filenames"] == ["a", "b"]
         assert r["num_files"] == 2
@@ -138,34 +144,40 @@ class TestParseToolResult:
         assert r["truncated"] is True
 
     def test_grep_result(self):
-        r = _parse_tool_result({
-            "mode": "content",
-            "numFiles": 3,
-            "numLines": 10,
-            "content": "matches",
-        })
+        r = _parse_tool_result(
+            {
+                "mode": "content",
+                "numFiles": 3,
+                "numLines": 10,
+                "content": "matches",
+            }
+        )
         assert r["result_type"] == "grep"
         assert r["mode"] == "content"
         assert r["content"] == "matches"
 
     def test_file_read_result(self):
-        r = _parse_tool_result({
-            "file": {
-                "filePath": "/r.md",
-                "numLines": 5,
-                "content": "body",
+        r = _parse_tool_result(
+            {
+                "file": {
+                    "filePath": "/r.md",
+                    "numLines": 5,
+                    "content": "body",
+                }
             }
-        })
+        )
         assert r["result_type"] == "file_read"
         assert r["file_path"] == "/r.md"
         assert r["content"] == "body"
 
     def test_web_search_result(self):
-        r = _parse_tool_result({
-            "query": "q",
-            "results": [{"url": "u"}],
-            "durationSeconds": 1.5,
-        })
+        r = _parse_tool_result(
+            {
+                "query": "q",
+                "results": [{"url": "u"}],
+                "durationSeconds": 1.5,
+            }
+        )
         assert r["result_type"] == "web_search"
         assert r["query"] == "q"
         assert r["result_count"] == 1
@@ -188,32 +200,38 @@ class TestParseToolResult:
         assert r["task_id"] == "t1"
 
     def test_task_retrieval_variant(self):
-        r = _parse_tool_result({
-            "retrieval_status": "ok",
-            "task": {"task_id": "tid"},
-        })
+        r = _parse_tool_result(
+            {
+                "retrieval_status": "ok",
+                "task": {"task_id": "tid"},
+            }
+        )
         assert r["result_type"] == "task"
         assert r["task_id"] == "tid"
 
     def test_task_completed_subagent(self):
-        r = _parse_tool_result({
-            "agentId": "ag",
-            "totalDurationMs": 500,
-            "status": "completed",
-            "totalTokens": 100,
-            "totalToolUseCount": 2,
-        })
+        r = _parse_tool_result(
+            {
+                "agentId": "ag",
+                "totalDurationMs": 500,
+                "status": "completed",
+                "totalTokens": 100,
+                "totalToolUseCount": 2,
+            }
+        )
         assert r["result_type"] == "task"
         assert r["agent_id"] == "ag"
         assert r["total_duration_ms"] == 500
 
     def test_task_async_launched(self):
-        r = _parse_tool_result({
-            "agentId": "ag2",
-            "isAsync": True,
-            "status": "running",
-            "description": "bg",
-        })
+        r = _parse_tool_result(
+            {
+                "agentId": "ag2",
+                "isAsync": True,
+                "status": "running",
+                "description": "bg",
+            }
+        )
         assert r["result_type"] == "task"
         assert r["agent_id"] == "ag2"
 
@@ -223,10 +241,12 @@ class TestParseToolResult:
         assert r["todo_count"] == 1
 
     def test_user_input_result(self):
-        r = _parse_tool_result({
-            "questions": [{"id": "q"}],
-            "answers": {"q": "a"},
-        })
+        r = _parse_tool_result(
+            {
+                "questions": [{"id": "q"}],
+                "answers": {"q": "a"},
+            }
+        )
         assert r["result_type"] == "user_input"
 
     def test_plan_result(self):
@@ -235,11 +255,13 @@ class TestParseToolResult:
 
     def test_plan_with_content_not_classified_as_file_write(self):
         """plan is registered before file_write in _TOOL_RESULT_DISPATCH."""
-        r = _parse_tool_result({
-            "plan": [],
-            "filePath": "/plan.md",
-            "content": "plan body",
-        })
+        r = _parse_tool_result(
+            {
+                "plan": [],
+                "filePath": "/plan.md",
+                "content": "plan body",
+            }
+        )
         assert r["result_type"] == "plan"
         assert r["file_path"] == "/plan.md"
 
@@ -259,6 +281,7 @@ class TestParseToolResult:
 # ---------------------------------------------------------------------------
 # _normalize_content, _extract_text, _extract_images
 # ---------------------------------------------------------------------------
+
 
 class TestNormalizeContent:
     def test_plain_string(self):
@@ -303,21 +326,31 @@ class TestExtractText:
 
 class TestExtractImages:
     def test_base64_image_extracted(self):
-        imgs = _extract_images([{
-            "type": "image",
-            "source": {"type": "base64", "data": "AAA", "media_type": "image/png"},
-        }])
+        imgs = _extract_images(
+            [
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "data": "AAA", "media_type": "image/png"},
+                }
+            ]
+        )
         assert len(imgs) == 1
         assert imgs[0]["data"] == "AAA"
 
     def test_nested_tool_result_image_extracted(self):
-        imgs = _extract_images([{
-            "type": "tool_result",
-            "content": [{
-                "type": "image",
-                "source": {"type": "base64", "data": "BBB"},
-            }],
-        }])
+        imgs = _extract_images(
+            [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {"type": "base64", "data": "BBB"},
+                        }
+                    ],
+                }
+            ]
+        )
         assert len(imgs) == 1
         assert imgs[0]["data"] == "BBB"
 
@@ -329,12 +362,15 @@ class TestExtractImages:
 # _infer_title, _strip_system_tags
 # ---------------------------------------------------------------------------
 
+
 class TestInferTitle:
     def test_first_user_message_used(self):
-        title = _infer_title([
-            {"role": "assistant", "text": "a"},
-            {"role": "user", "text": "My title line\nmore"},
-        ])
+        title = _infer_title(
+            [
+                {"role": "assistant", "text": "a"},
+                {"role": "user", "text": "My title line\nmore"},
+            ]
+        )
         assert title == "My title line"
 
     def test_truncated_to_100_chars(self):
@@ -375,26 +411,35 @@ class TestStripSystemTags:
 # _process_user
 # ---------------------------------------------------------------------------
 
+
 class TestProcessUser:
     def test_metadata_captured_from_first_entry_only(self):
         messages = []
         meta = _fresh_metadata()
-        _process_user({
-            "type": "user",
-            "version": 1,
-            "cwd": "/first",
-            "gitBranch": "main",
-            "permissionMode": "default",
-            "message": {"content": [{"type": "text", "text": "a"}]},
-        }, messages, meta)
-        _process_user({
-            "type": "user",
-            "version": 2,
-            "cwd": "/second",
-            "gitBranch": "dev",
-            "permissionMode": "all",
-            "message": {"content": [{"type": "text", "text": "b"}]},
-        }, messages, meta)
+        _process_user(
+            {
+                "type": "user",
+                "version": 1,
+                "cwd": "/first",
+                "gitBranch": "main",
+                "permissionMode": "default",
+                "message": {"content": [{"type": "text", "text": "a"}]},
+            },
+            messages,
+            meta,
+        )
+        _process_user(
+            {
+                "type": "user",
+                "version": 2,
+                "cwd": "/second",
+                "gitBranch": "dev",
+                "permissionMode": "all",
+                "message": {"content": [{"type": "text", "text": "b"}]},
+            },
+            messages,
+            meta,
+        )
         assert meta["version"] == 1
         assert meta["cwd"] == "/first"
         assert meta["git_branch"] == "main"
@@ -410,15 +455,21 @@ class TestProcessUser:
     def test_tool_use_result_images_extracted(self):
         messages = []
         meta = _fresh_metadata()
-        _process_user({
-            "message": {"content": []},
-            "toolUseResult": {
-                "content": [{
-                    "type": "image",
-                    "source": {"type": "base64", "data": "IMG"},
-                }],
+        _process_user(
+            {
+                "message": {"content": []},
+                "toolUseResult": {
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {"type": "base64", "data": "IMG"},
+                        }
+                    ],
+                },
             },
-        }, messages, meta)
+            messages,
+            meta,
+        )
         assert messages[0]["images"]
         assert messages[0]["images"][0]["data"] == "IMG"
 
@@ -427,113 +478,150 @@ class TestProcessUser:
 # _process_assistant
 # ---------------------------------------------------------------------------
 
+
 class TestProcessAssistant:
     def test_content_plain_string_normalized(self):
         messages = []
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": "plain string body",
-                "usage": {},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": "plain string body",
+                    "usage": {},
+                },
             },
-        }, messages, meta)
+            messages,
+            meta,
+        )
         assert messages[0]["text"] == "plain string body"
 
     def test_synthetic_model_not_added(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "<synthetic>",
-                "content": [{"type": "text", "text": "x"}],
-                "usage": {},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "<synthetic>",
+                    "content": [{"type": "text", "text": "x"}],
+                    "usage": {},
+                },
             },
-        }, [], meta)
+            [],
+            meta,
+        )
         assert meta["models_used"] == set()
 
     def test_thinking_blocks_joined(self):
         messages = []
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [
-                    {"type": "thinking", "thinking": "t1"},
-                    {"type": "thinking", "thinking": "t2"},
-                ],
-                "usage": {},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [
+                        {"type": "thinking", "thinking": "t1"},
+                        {"type": "thinking", "thinking": "t2"},
+                    ],
+                    "usage": {},
+                },
             },
-        }, messages, meta)
+            messages,
+            meta,
+        )
         assert messages[0]["thinking"] == "t1\n\nt2"
 
     def test_tool_use_counts_accumulated(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [
-                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/a"}},
-                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/b"}},
-                ],
-                "usage": {},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": "/a"}},
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": "/b"}},
+                    ],
+                    "usage": {},
+                },
             },
-        }, [], meta)
+            [],
+            meta,
+        )
         assert meta["total_tool_calls"] == 2
         assert meta["tool_call_counts"]["Read"] == 2
 
     def test_api_error_flag_increments_api_errors(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "isApiErrorMessage": True,
-            "message": {"model": "m", "content": [], "usage": {}},
-        }, [], meta)
+        _process_assistant(
+            {
+                "isApiErrorMessage": True,
+                "message": {"model": "m", "content": [], "usage": {}},
+            },
+            [],
+            meta,
+        )
         assert meta["api_errors"] == 1
 
     def test_stop_reason_accumulated(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [],
-                "stop_reason": "max_tokens",
-                "usage": {},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [],
+                    "stop_reason": "max_tokens",
+                    "usage": {},
+                },
             },
-        }, [], meta)
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [],
-                "stop_reason": "max_tokens",
-                "usage": {},
+            [],
+            meta,
+        )
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [],
+                    "stop_reason": "max_tokens",
+                    "usage": {},
+                },
             },
-        }, [], meta)
+            [],
+            meta,
+        )
         assert meta["stop_reasons"]["max_tokens"] == 2
 
     def test_service_tier_added(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [],
-                "usage": {"service_tier": "priority"},
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [],
+                    "usage": {"service_tier": "priority"},
+                },
             },
-        }, [], meta)
+            [],
+            meta,
+        )
         assert "priority" in meta["service_tiers"]
 
     def test_ephemeral_cache_tokens_accumulated(self):
         meta = _fresh_metadata()
-        _process_assistant({
-            "message": {
-                "model": "m",
-                "content": [],
-                "usage": {
-                    "cache_creation": {
-                        "ephemeral_5m_input_tokens": 7,
-                        "ephemeral_1h_input_tokens": 3,
+        _process_assistant(
+            {
+                "message": {
+                    "model": "m",
+                    "content": [],
+                    "usage": {
+                        "cache_creation": {
+                            "ephemeral_5m_input_tokens": 7,
+                            "ephemeral_1h_input_tokens": 3,
+                        },
                     },
                 },
             },
-        }, [], meta)
+            [],
+            meta,
+        )
         assert meta["total_ephemeral_5m_tokens"] == 7
         assert meta["total_ephemeral_1h_tokens"] == 3
 
@@ -541,6 +629,7 @@ class TestProcessAssistant:
 # ---------------------------------------------------------------------------
 # _track_file_activity
 # ---------------------------------------------------------------------------
+
 
 class TestTrackFileActivity:
     def _meta(self):
@@ -592,15 +681,20 @@ class TestTrackFileActivity:
 # _process_system
 # ---------------------------------------------------------------------------
 
+
 class TestProcessSystem:
     def test_compact_boundary_increments_compaction(self):
         messages = []
         meta = _fresh_metadata()
-        _process_system({
-            "subtype": "compact_boundary",
-            "timestamp": "2026-01-01T00:00:00Z",
-            "compactMetadata": {"trigger": "size", "preTokens": 100},
-        }, messages, meta)
+        _process_system(
+            {
+                "subtype": "compact_boundary",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "compactMetadata": {"trigger": "size", "preTokens": 100},
+            },
+            messages,
+            meta,
+        )
         assert meta["compactions"] == 1
         assert len(meta["compact_boundaries"]) == 1
         assert meta["compact_boundaries"][0]["trigger"] == "size"
@@ -608,10 +702,14 @@ class TestProcessSystem:
     def test_compact_boundary_missing_metadata_no_crash(self):
         messages = []
         meta = _fresh_metadata()
-        _process_system({
-            "subtype": "compact_boundary",
-            "compactMetadata": None,
-        }, messages, meta)
+        _process_system(
+            {
+                "subtype": "compact_boundary",
+                "compactMetadata": None,
+            },
+            messages,
+            meta,
+        )
         assert meta["compactions"] == 1
         assert meta["compact_boundaries"] == []
 
@@ -627,6 +725,7 @@ class TestProcessSystem:
 # parse_session (integration)
 # ---------------------------------------------------------------------------
 
+
 class TestParseSession:
     def test_empty_file_returns_skeleton(self):
         path = _write_jsonl([])
@@ -639,9 +738,11 @@ class TestParseSession:
             os.unlink(path)
 
     def test_unknown_entry_type_silently_ignored(self):
-        path = _write_jsonl([
-            {"type": "custom", "timestamp": "2026-01-01T00:00:00Z"},
-        ])
+        path = _write_jsonl(
+            [
+                {"type": "custom", "timestamp": "2026-01-01T00:00:00Z"},
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["messages"] == []
@@ -650,14 +751,16 @@ class TestParseSession:
             os.unlink(path)
 
     def test_is_sidechain_increments_counter(self):
-        path = _write_jsonl([
-            {
-                "type": "user",
-                "isSidechain": True,
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"content": [{"type": "text", "text": "s"}]},
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "user",
+                    "isSidechain": True,
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": {"content": [{"type": "text", "text": "s"}]},
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["sidechain_messages"] == 1
@@ -665,12 +768,14 @@ class TestParseSession:
             os.unlink(path)
 
     def test_file_history_snapshot_timestamp(self):
-        path = _write_jsonl([
-            {
-                "type": "file-history-snapshot",
-                "snapshot": {"timestamp": "2026-01-02T12:00:00Z"},
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "file-history-snapshot",
+                    "snapshot": {"timestamp": "2026-01-02T12:00:00Z"},
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["first_timestamp"] == "2026-01-02T12:00:00Z"
@@ -698,10 +803,12 @@ class TestParseSession:
             os.unlink(path)
 
     def test_wall_time_computed(self):
-        path = _write_jsonl([
-            {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": []}},
-            {"type": "user", "timestamp": "2026-01-01T01:00:00Z", "message": {"content": []}},
-        ])
+        path = _write_jsonl(
+            [
+                {"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": []}},
+                {"type": "user", "timestamp": "2026-01-01T01:00:00Z", "message": {"content": []}},
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["session_wall_time_seconds"] == 3600.0
@@ -713,11 +820,16 @@ class TestParseSession:
         # append bad line
         with open(path, "a", encoding="utf-8") as f:
             f.write("{not json\n")
-            f.write(json.dumps({
-                "type": "user",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"content": [{"type": "text", "text": "ok"}]},
-            }) + "\n")
+            f.write(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "message": {"content": [{"type": "text", "text": "ok"}]},
+                    }
+                )
+                + "\n"
+            )
         try:
             s = parse_session(path)
             assert any(m.get("text") == "ok" for m in s["messages"])
@@ -725,9 +837,11 @@ class TestParseSession:
             os.unlink(path)
 
     def test_missing_type_key_no_crash(self):
-        path = _write_jsonl([
-            {"timestamp": "2026-01-01T00:00:00Z"},
-        ])
+        path = _write_jsonl(
+            [
+                {"timestamp": "2026-01-01T00:00:00Z"},
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["messages"] == []
@@ -735,13 +849,15 @@ class TestParseSession:
             os.unlink(path)
 
     def test_missing_usage_dict_no_crash(self):
-        path = _write_jsonl([
-            {
-                "type": "assistant",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"model": "m", "content": [], "usage": None},
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": {"model": "m", "content": [], "usage": None},
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["total_input_tokens"] == 0
@@ -749,13 +865,15 @@ class TestParseSession:
             os.unlink(path)
 
     def test_null_message_assistant_no_crash(self):
-        path = _write_jsonl([
-            {
-                "type": "assistant",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": None,
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": None,
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["total_input_tokens"] == 0
@@ -765,13 +883,15 @@ class TestParseSession:
             os.unlink(path)
 
     def test_non_dict_message_assistant_no_crash(self):
-        path = _write_jsonl([
-            {
-                "type": "assistant",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": "not-a-dict",
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": "not-a-dict",
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["total_input_tokens"] == 0
@@ -781,13 +901,15 @@ class TestParseSession:
             os.unlink(path)
 
     def test_non_dict_usage_assistant_no_crash(self):
-        path = _write_jsonl([
-            {
-                "type": "assistant",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"model": "m", "content": [], "usage": "invalid"},
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": {"model": "m", "content": [], "usage": "invalid"},
+                },
+            ]
+        )
         try:
             s = parse_session(path)
             assert s["metadata"]["total_input_tokens"] == 0
@@ -799,20 +921,23 @@ class TestParseSession:
 # quick_session_info
 # ---------------------------------------------------------------------------
 
+
 class TestQuickSessionInfo:
     def test_small_file_title_and_timestamps(self):
-        path = _write_jsonl([
-            {
-                "type": "user",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {"content": [{"type": "text", "text": "Hello Title"}]},
-            },
-            {
-                "type": "assistant",
-                "timestamp": "2026-01-01T00:30:00Z",
-                "message": {"model": "m", "content": [], "usage": {}},
-            },
-        ])
+        path = _write_jsonl(
+            [
+                {
+                    "type": "user",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": {"content": [{"type": "text", "text": "Hello Title"}]},
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:30:00Z",
+                    "message": {"model": "m", "content": [], "usage": {}},
+                },
+            ]
+        )
         try:
             info = quick_session_info(path)
             assert info["title"] == "Hello Title"
@@ -825,20 +950,24 @@ class TestQuickSessionInfo:
         # Build >10000 bytes; early timestamps, last line has later ts
         lines = []
         for i in range(200):
-            lines.append({
+            lines.append(
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "message": {
+                        "model": "m",
+                        "content": [{"type": "text", "text": "x" * 80}],
+                        "usage": {},
+                    },
+                }
+            )
+        lines.append(
+            {
                 "type": "assistant",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "message": {
-                    "model": "m",
-                    "content": [{"type": "text", "text": "x" * 80}],
-                    "usage": {},
-                },
-            })
-        lines.append({
-            "type": "assistant",
-            "timestamp": "2026-12-31T23:59:59Z",
-            "message": {"model": "m", "content": [], "usage": {}},
-        })
+                "timestamp": "2026-12-31T23:59:59Z",
+                "message": {"model": "m", "content": [], "usage": {}},
+            }
+        )
         path = _write_jsonl(lines)
         try:
             assert os.path.getsize(path) > 10000
@@ -865,11 +994,14 @@ class TestQuickSessionInfo:
 # Extra malformed cases (Gap 9)
 # ---------------------------------------------------------------------------
 
+
 class TestMalformedPartialEntries:
     def test_assistant_missing_message_key(self):
-        path = _write_jsonl([
-            {"type": "assistant", "timestamp": "2026-01-01T00:00:00Z"},
-        ])
+        path = _write_jsonl(
+            [
+                {"type": "assistant", "timestamp": "2026-01-01T00:00:00Z"},
+            ]
+        )
         try:
             s = parse_session(path)
             assert len(s["messages"]) == 1
@@ -880,17 +1012,25 @@ class TestMalformedPartialEntries:
     def test_tool_use_result_null_returns_none_in_message(self):
         messages = []
         meta = _fresh_metadata()
-        _process_user({
-            "message": {"content": []},
-            "toolUseResult": None,
-        }, messages, meta)
+        _process_user(
+            {
+                "message": {"content": []},
+                "toolUseResult": None,
+            },
+            messages,
+            meta,
+        )
         assert messages[0]["tool_result_parsed"] is None
 
     def test_tool_use_result_string_returns_none(self):
         messages = []
         meta = _fresh_metadata()
-        _process_user({
-            "message": {"content": []},
-            "toolUseResult": "oops",
-        }, messages, meta)
+        _process_user(
+            {
+                "message": {"content": []},
+                "toolUseResult": "oops",
+            },
+            messages,
+            meta,
+        )
         assert messages[0]["tool_result_parsed"] is None

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -8,9 +8,9 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from models.errors import SessionValidationError  # noqa: E402
-from utils.jsonl_parser import parse_session  # noqa: E402
-from utils.validation import validate_session_dict  # noqa: E402
+from models.errors import SessionValidationError
+from utils.jsonl_parser import parse_session
+from utils.validation import validate_session_dict
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -47,16 +47,12 @@ class TestValidateSessionDict:
 
     def test_null_role_in_message(self):
         with pytest.raises(SessionValidationError) as exc_info:
-            validate_session_dict(
-                _valid_payload(messages=[{"role": None, "text": "x"}])
-            )
+            validate_session_dict(_valid_payload(messages=[{"role": None, "text": "x"}]))
         assert exc_info.value.path == "messages[0].role"
 
     def test_missing_role_in_message(self):
         with pytest.raises(SessionValidationError) as exc_info:
-            validate_session_dict(
-                _valid_payload(messages=[{"text": "no role key"}])
-            )
+            validate_session_dict(_valid_payload(messages=[{"text": "no role key"}]))
         assert exc_info.value.path == "messages[0].role"
 
     def test_metadata_not_dict(self):

--- a/tests/test_null_usage_tokens.py
+++ b/tests/test_null_usage_tokens.py
@@ -25,6 +25,7 @@ from utils.session_stats import _estimate_cost
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _fresh_metadata() -> dict:
     """Return a minimal metadata dict matching what parse_session initialises."""
     return {
@@ -79,14 +80,20 @@ def _assistant_entry(usage: dict) -> dict:
 # _process_assistant: null fields must not raise
 # ---------------------------------------------------------------------------
 
+
 class TestProcessAssistantNullUsage:
     """Unit tests for _process_assistant with null token values."""
 
     def test_null_cache_read_tokens(self):
         meta = _fresh_metadata()
-        entry = _assistant_entry({"input_tokens": 100, "output_tokens": 50,
-                                  "cache_read_input_tokens": None,
-                                  "cache_creation_input_tokens": 0})
+        entry = _assistant_entry(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": 0,
+            }
+        )
         _process_assistant(entry, [], meta)
         assert meta["total_input_tokens"] == 100
         assert meta["total_output_tokens"] == 50
@@ -94,9 +101,14 @@ class TestProcessAssistantNullUsage:
 
     def test_null_cache_creation_tokens(self):
         meta = _fresh_metadata()
-        entry = _assistant_entry({"input_tokens": 200, "output_tokens": 80,
-                                  "cache_read_input_tokens": 0,
-                                  "cache_creation_input_tokens": None})
+        entry = _assistant_entry(
+            {
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": None,
+            }
+        )
         _process_assistant(entry, [], meta)
         assert meta["total_cache_creation_tokens"] == 0
 
@@ -116,12 +128,14 @@ class TestProcessAssistantNullUsage:
 
     def test_all_null_usage_fields(self):
         meta = _fresh_metadata()
-        entry = _assistant_entry({
-            "input_tokens": None,
-            "output_tokens": None,
-            "cache_read_input_tokens": None,
-            "cache_creation_input_tokens": None,
-        })
+        entry = _assistant_entry(
+            {
+                "input_tokens": None,
+                "output_tokens": None,
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+            }
+        )
         _process_assistant(entry, [], meta)
         assert meta["total_input_tokens"] == 0
         assert meta["total_output_tokens"] == 0
@@ -130,14 +144,16 @@ class TestProcessAssistantNullUsage:
 
     def test_null_ephemeral_tokens(self):
         meta = _fresh_metadata()
-        entry = _assistant_entry({
-            "input_tokens": 10,
-            "output_tokens": 5,
-            "cache_creation": {
-                "ephemeral_5m_input_tokens": None,
-                "ephemeral_1h_input_tokens": None,
-            },
-        })
+        entry = _assistant_entry(
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": None,
+                    "ephemeral_1h_input_tokens": None,
+                },
+            }
+        )
         _process_assistant(entry, [], meta)
         assert meta["total_ephemeral_5m_tokens"] == 0
         assert meta["total_ephemeral_1h_tokens"] == 0
@@ -146,12 +162,14 @@ class TestProcessAssistantNullUsage:
         """The usage dict stored on the message itself must never contain None."""
         messages = []
         meta = _fresh_metadata()
-        entry = _assistant_entry({
-            "input_tokens": None,
-            "output_tokens": None,
-            "cache_read_input_tokens": None,
-            "cache_creation_input_tokens": None,
-        })
+        entry = _assistant_entry(
+            {
+                "input_tokens": None,
+                "output_tokens": None,
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+            }
+        )
         _process_assistant(entry, messages, meta)
         assert len(messages) == 1
         usage = messages[0]["usage"]
@@ -164,12 +182,14 @@ class TestProcessAssistantNullUsage:
         """Sanity check: valid integer values are accumulated correctly."""
         meta = _fresh_metadata()
         for _ in range(3):
-            entry = _assistant_entry({
-                "input_tokens": 100,
-                "output_tokens": 50,
-                "cache_read_input_tokens": 20,
-                "cache_creation_input_tokens": 10,
-            })
+            entry = _assistant_entry(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 20,
+                    "cache_creation_input_tokens": 10,
+                }
+            )
             _process_assistant(entry, [], meta)
         assert meta["total_input_tokens"] == 300
         assert meta["total_output_tokens"] == 150
@@ -181,27 +201,30 @@ class TestProcessAssistantNullUsage:
 # parse_session (integration): null usage survives round-trip via temp file
 # ---------------------------------------------------------------------------
 
+
 class TestParseSessionNullUsage:
     """Integration tests: parse_session must not raise on null usage fields."""
 
     def _write_session(self, entries: list) -> str:
-        f = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
-        )
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False, encoding="utf-8")
         for entry in entries:
             f.write(json.dumps(entry) + "\n")
         f.close()
         return f.name
 
     def test_null_cache_read_does_not_crash(self):
-        path = self._write_session([
-            _assistant_entry({
-                "input_tokens": 500,
-                "output_tokens": 100,
-                "cache_read_input_tokens": None,
-                "cache_creation_input_tokens": None,
-            })
-        ])
+        path = self._write_session(
+            [
+                _assistant_entry(
+                    {
+                        "input_tokens": 500,
+                        "output_tokens": 100,
+                        "cache_read_input_tokens": None,
+                        "cache_creation_input_tokens": None,
+                    }
+                )
+            ]
+        )
         try:
             session = parse_session(path)
             assert session["metadata"]["total_input_tokens"] == 500
@@ -212,12 +235,16 @@ class TestParseSessionNullUsage:
     def test_mixed_null_and_normal_entries(self):
         """A session with some null-usage entries and some normal ones should
         accumulate only the non-null values."""
-        path = self._write_session([
-            _assistant_entry({"input_tokens": 100, "output_tokens": 40,
-                              "cache_read_input_tokens": None}),
-            _assistant_entry({"input_tokens": 200, "output_tokens": 80,
-                              "cache_read_input_tokens": 30}),
-        ])
+        path = self._write_session(
+            [
+                _assistant_entry(
+                    {"input_tokens": 100, "output_tokens": 40, "cache_read_input_tokens": None}
+                ),
+                _assistant_entry(
+                    {"input_tokens": 200, "output_tokens": 80, "cache_read_input_tokens": 30}
+                ),
+            ]
+        )
         try:
             session = parse_session(path)
             assert session["metadata"]["total_input_tokens"] == 300
@@ -231,41 +258,49 @@ class TestParseSessionNullUsage:
 # _estimate_cost: null tokens must not crash cost calculation
 # ---------------------------------------------------------------------------
 
+
 class TestEstimateCostNullUsage:
     """Unit tests for _estimate_cost with null token values."""
 
     def _make_messages(self, usage_list: list) -> list:
         return [
-            {"role": "assistant", "model": model, "usage": usage}
-            for model, usage in usage_list
+            {"role": "assistant", "model": model, "usage": usage} for model, usage in usage_list
         ]
 
     def test_null_output_tokens_with_valid_input(self):
-        messages = self._make_messages([
-            ("claude-sonnet-4-5", {"input_tokens": 1_000_000, "output_tokens": None}),
-        ])
+        messages = self._make_messages(
+            [
+                ("claude-sonnet-4-5", {"input_tokens": 1_000_000, "output_tokens": None}),
+            ]
+        )
         cost = _estimate_cost(messages, {})
         assert cost is not None
         assert cost == pytest.approx(3.0, rel=1e-3)
 
     def test_null_input_tokens_with_valid_output(self):
-        messages = self._make_messages([
-            ("claude-sonnet-4-5", {"input_tokens": None, "output_tokens": 1_000_000}),
-        ])
+        messages = self._make_messages(
+            [
+                ("claude-sonnet-4-5", {"input_tokens": None, "output_tokens": 1_000_000}),
+            ]
+        )
         cost = _estimate_cost(messages, {})
         assert cost is not None
         assert cost == pytest.approx(15.0, rel=1e-3)
 
     def test_all_null_tokens_returns_none(self):
-        messages = self._make_messages([
-            ("claude-sonnet-4-5", {"input_tokens": None, "output_tokens": None}),
-        ])
+        messages = self._make_messages(
+            [
+                ("claude-sonnet-4-5", {"input_tokens": None, "output_tokens": None}),
+            ]
+        )
         cost = _estimate_cost(messages, {})
         assert cost is None
 
     def test_normal_values_unaffected(self):
-        messages = self._make_messages([
-            ("claude-sonnet-4-5", {"input_tokens": 1_000_000, "output_tokens": 1_000_000}),
-        ])
+        messages = self._make_messages(
+            [
+                ("claude-sonnet-4-5", {"input_tokens": 1_000_000, "output_tokens": 1_000_000}),
+            ]
+        )
         cost = _estimate_cost(messages, {})
         assert cost == pytest.approx(18.0, rel=1e-3)

--- a/tests/test_null_usage_tokens.py
+++ b/tests/test_null_usage_tokens.py
@@ -18,9 +18,8 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from utils.jsonl_parser import parse_session, _process_assistant
+from utils.jsonl_parser import _process_assistant, parse_session
 from utils.session_stats import _estimate_cost
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_real_session_fixtures.py
+++ b/tests/test_real_session_fixtures.py
@@ -124,9 +124,7 @@ def test_real_session_nested_tools_has_sidechain_and_tool_use() -> None:
 def test_real_session_unknown_fields_tolerated() -> None:
     session = parse_session(_fixture_path("real_session_unknown_fields.jsonl"))
     _assert_session_shape(session)
-    assert len(session["messages"]) == _FIXTURE_MESSAGE_COUNTS[
-        "real_session_unknown_fields.jsonl"
-    ]
+    assert len(session["messages"]) == _FIXTURE_MESSAGE_COUNTS["real_session_unknown_fields.jsonl"]
 
 
 def test_real_session_malformed_lines_skips_bad_lines() -> None:
@@ -135,9 +133,7 @@ def test_real_session_malformed_lines_skips_bad_lines() -> None:
     texts = [m.get("text") or "" for m in session["messages"] if m["role"] == "user"]
     assert any("before malformed" in t for t in texts)
     assert any("after malformed" in t for t in texts)
-    assert len(session["messages"]) == _FIXTURE_MESSAGE_COUNTS[
-        "real_session_malformed_lines.jsonl"
-    ]
+    assert len(session["messages"]) == _FIXTURE_MESSAGE_COUNTS["real_session_malformed_lines.jsonl"]
 
 
 def test_task_retrieval_not_misclassified_as_task_message() -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,14 +7,16 @@ from __future__ import annotations
 
 from tests.conftest import assert_error_response
 
-_SEARCH_HIT_KEYS = frozenset({
-    "project",
-    "session_id",
-    "title",
-    "role",
-    "timestamp",
-    "snippet",
-})
+_SEARCH_HIT_KEYS = frozenset(
+    {
+        "project",
+        "session_id",
+        "title",
+        "role",
+        "timestamp",
+        "snippet",
+    }
+)
 
 
 def _assert_search_hits(results: list, *, max_items: int) -> None:

--- a/tests/test_session_path.py
+++ b/tests/test_session_path.py
@@ -14,9 +14,10 @@ from utils import session_path
 def test_get_claude_projects_dir_uses_userprofile_on_windows(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Linux/Windows CI smoke: patch ``session_path.platform.system`` (needs ``import platform`` in module).
+    """Linux/Windows CI smoke: patch ``session_path.platform.system``.
 
-    If ``session_path`` ever switches to ``from platform import system``, this patch
+    Requires ``import platform`` in the module under test. If ``session_path`` ever
+    switches to ``from platform import system``, this patch
     no-ops but may still pass on Linux via ``expanduser("~")``. Real Windows behavior
     is covered by ``test_get_claude_projects_dir_on_windows_runner`` (win32-only).
     """

--- a/tests/test_xss_sanitization.py
+++ b/tests/test_xss_sanitization.py
@@ -26,25 +26,21 @@ STATIC_JS_DIR = REPO_ROOT / "static" / "js"
 
 DOMPURIFY_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.7/purify.min.js"
 DOMPURIFY_SRI = (
-    "sha512-78KH17QLT5e55GJqP76vutp1D2iAoy06WcYBXB6iBCsmO6wWzx0Qdg8EDpm8mKXv68BcvHOyeeP4wxAL0twJGQ=="
+    "sha512-78KH17QLT5e55GJqP76vutp1D2iAoy06WcYBXB6iBCsmO6wWzx0Qdg8EDpm8mKXv68BcvHOyee"
+    "P4wxAL0twJGQ=="
 )
 
 
 def _all_js_files():
     """Return all .js files under static/js/, excluding node_modules."""
-    return [
-        p for p in STATIC_JS_DIR.rglob("*.js")
-        if "node_modules" not in p.parts
-    ]
+    return [p for p in STATIC_JS_DIR.rglob("*.js") if "node_modules" not in p.parts]
 
 
 class TestDomPurifyInHTML:
-
     def test_dompurify_cdn_url_present(self):
         html = INDEX_HTML.read_text(encoding="utf-8")
         assert DOMPURIFY_CDN_URL in html, (
-            f"DOMPurify CDN URL not found in index.html. "
-            f"Expected: {DOMPURIFY_CDN_URL}"
+            f"DOMPurify CDN URL not found in index.html. Expected: {DOMPURIFY_CDN_URL}"
         )
 
     def test_dompurify_sri_hash_present(self):
@@ -58,19 +54,18 @@ class TestDomPurifyInHTML:
         html = INDEX_HTML.read_text(encoding="utf-8")
         # Find the script tag that loads DOMPurify and check crossorigin attribute
         script_re = re.compile(
-            r'<script\b[^>]*' + re.escape("dompurify") + r'[^>]*>',
+            r"<script\b[^>]*" + re.escape("dompurify") + r"[^>]*>",
             re.DOTALL | re.IGNORECASE,
         )
         m = script_re.search(html)
         assert m, "No <script> tag referencing dompurify found in index.html"
         tag = m.group(0)
         assert 'crossorigin="anonymous"' in tag, (
-            f"DOMPurify <script> tag missing crossorigin=\"anonymous\": {tag!r}"
+            f'DOMPurify <script> tag missing crossorigin="anonymous": {tag!r}'
         )
 
 
 class TestRenderMarkdownSanitizes:
-
     def test_render_markdown_calls_dompurify_sanitize(self):
         """renderMarkdown must pass marked.parse output through DOMPurify.sanitize."""
         src = MARKDOWN_JS.read_text(encoding="utf-8")
@@ -103,7 +98,6 @@ class TestRenderMarkdownSanitizes:
 
 
 class TestNoDirectMarkedParseOutsideWrapper:
-
     def test_only_shared_markdown_calls_marked_parse(self):
         """No JS file other than shared/markdown.js may call marked.parse() directly."""
         violations = []
@@ -122,7 +116,7 @@ class TestNoDirectMarkedParseOutsideWrapper:
     def test_no_raw_marked_parse_to_inner_html(self):
         """No JS file may assign a marked.parse() result directly to innerHTML."""
         # Pattern: innerHTML = ... marked.parse(...) without DOMPurify wrapping
-        raw_assign_re = re.compile(r'innerHTML\s*[+]?=.*marked\.parse\s*\(', re.DOTALL)
+        raw_assign_re = re.compile(r"innerHTML\s*[+]?=.*marked\.parse\s*\(", re.DOTALL)
         violations = []
         for js_file in _all_js_files():
             src = js_file.read_text(encoding="utf-8")

--- a/tests/test_xss_sanitization.py
+++ b/tests/test_xss_sanitization.py
@@ -25,7 +25,9 @@ MARKDOWN_JS = REPO_ROOT / "static" / "js" / "shared" / "markdown.js"
 STATIC_JS_DIR = REPO_ROOT / "static" / "js"
 
 DOMPURIFY_CDN_URL = "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.7/purify.min.js"
-DOMPURIFY_SRI = "sha512-78KH17QLT5e55GJqP76vutp1D2iAoy06WcYBXB6iBCsmO6wWzx0Qdg8EDpm8mKXv68BcvHOyeeP4wxAL0twJGQ=="
+DOMPURIFY_SRI = (
+    "sha512-78KH17QLT5e55GJqP76vutp1D2iAoy06WcYBXB6iBCsmO6wWzx0Qdg8EDpm8mKXv68BcvHOyeeP4wxAL0twJGQ=="
+)
 
 
 def _all_js_files():

--- a/utils/exclusion_rules.py
+++ b/utils/exclusion_rules.py
@@ -57,9 +57,7 @@ def resolve_exclusion_rules_path(cli_path: str | None) -> str | None:
     if cli_path:
         p = os.path.abspath(os.path.expanduser(cli_path))
         if not os.path.isfile(p):
-            _logger.warning(
-                "Exclusion rules file not found: %s — no filtering will be applied.", p
-            )
+            _logger.warning("Exclusion rules file not found: %s — no filtering will be applied.", p)
         return p
     default = get_default_exclusion_rules_path()
     if os.path.isfile(default):
@@ -79,7 +77,7 @@ def _tokenize_rule(line: str) -> list[Any]:
     while rest:
         m = re.match(r"\s+", rest)
         if m:
-            rest = rest[m.end():]
+            rest = rest[m.end() :]
             continue
         if re.match(r"\bAND\b", rest, re.IGNORECASE):
             tokens.append("AND")
@@ -95,12 +93,12 @@ def _tokenize_rule(line: str) -> list[Any]:
                 tokens.append(("word", rest[1:].strip()))
                 break
             tokens.append(("phrase", rest[1:end]))
-            rest = rest[end + 1:].lstrip()
+            rest = rest[end + 1 :].lstrip()
             continue
         m = re.match(r"\S+", rest)
         if m:
             tokens.append(("word", m.group(0)))
-            rest = rest[m.end():].lstrip()
+            rest = rest[m.end() :].lstrip()
             continue
         break
     return tokens

--- a/utils/export_day_filter.py
+++ b/utils/export_day_filter.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 def iso_timestamp_to_date(ts: str | None) -> date | None:
-    """Calendar date in UTC for an ISO-8601 *ts* (offset-aware → convert; naive → that instant's date)."""
+    """Calendar date in UTC for ISO-8601 *ts*.
+
+    Offset-aware values are converted to UTC; naive values use that instant's date.
+    """
     if not ts or not isinstance(ts, str):
         return None
     s = ts.strip()

--- a/utils/export_engine.py
+++ b/utils/export_engine.py
@@ -133,15 +133,13 @@ class ZipSink:
             self._zf.writestr("manifest.jsonl", body)
 
 
-def _resolve_first_timestamp(
-    meta: SessionMetadataDict, sess_info: SessionListItemDict
-) -> str:
+def _resolve_first_timestamp(meta: SessionMetadataDict, sess_info: SessionListItemDict) -> str:
     """Return first_timestamp from metadata, or synthesise from mtime without mutating *meta*."""
     ts = (meta.get("first_timestamp") or "").strip()
     if not ts:
-        ts = datetime.fromtimestamp(
-            sess_info["modified"], tz=timezone.utc
-        ).strftime("%Y-%m-%dT%H:%M:%S")
+        ts = datetime.fromtimestamp(sess_info["modified"], tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
     return ts
 
 
@@ -221,9 +219,7 @@ def _session_files(
         md = session_to_markdown(session, stats)
         files.append(
             (
-                build_export_rel_path(
-                    project, session, sess_info, "md", layout=layout
-                ),
+                build_export_rel_path(project, session, sess_info, "md", layout=layout),
                 md,
             )
         )
@@ -231,9 +227,7 @@ def _session_files(
         js = session_to_json(session, stats)
         files.append(
             (
-                build_export_rel_path(
-                    project, session, sess_info, "json", layout=layout
-                ),
+                build_export_rel_path(project, session, sess_info, "json", layout=layout),
                 js,
             )
         )
@@ -281,12 +275,8 @@ def run_bulk_export(
         sid = sess_info["id"]
         try:
             stats = compute_stats(session)
-            files = _session_files(
-                session, stats, project, sess_info, fmt, path_layout
-            )
-            entry = build_manifest_entry(
-                project, sess_info, session, stats, style=manifest_style
-            )
+            files = _session_files(session, stats, project, sess_info, fmt, path_layout)
+            entry = build_manifest_entry(project, sess_info, session, stats, style=manifest_style)
             sink.add_session(files, entry)
             manifest.append(entry)
             result.exports.extend(files)

--- a/utils/export_state_store.py
+++ b/utils/export_state_store.py
@@ -15,6 +15,7 @@ from models.export import ExportStateDict
 fcntl: Any
 try:
     import fcntl as _fcntl_mod
+
     fcntl = _fcntl_mod
 except ImportError:
     fcntl = None
@@ -22,6 +23,7 @@ except ImportError:
 msvcrt: Any
 try:
     import msvcrt as _msvcrt_mod
+
     msvcrt = _msvcrt_mod
 except ImportError:
     msvcrt = None
@@ -115,9 +117,7 @@ def load_export_state_from_disk(state_path: str | None = None) -> ExportStateDic
     return cast(ExportStateDict, data)
 
 
-def atomic_write_export_state(
-    state: ExportStateDict, state_path: str | None = None
-) -> None:
+def atomic_write_export_state(state: ExportStateDict, state_path: str | None = None) -> None:
     """Write *state* atomically (serialize, temp file + fsync + replace).
 
     Call under :func:`export_state_lock` matching *state_path*.

--- a/utils/jsonl_helpers.py
+++ b/utils/jsonl_helpers.py
@@ -46,10 +46,12 @@ def extract_images(content_parts: Any) -> list[dict[str, Any]]:
         if part.get("type") == "image":
             source = part.get("source", {})
             if source.get("type") == "base64" and source.get("data"):
-                images.append({
-                    "media_type": source.get("media_type", "image/png"),
-                    "data": source["data"],
-                })
+                images.append(
+                    {
+                        "media_type": source.get("media_type", "image/png"),
+                        "data": source["data"],
+                    }
+                )
         elif part.get("type") == "tool_result":
             # Nested content is usually a block list; string content is not normalized here.
             nested = part.get("content", [])
@@ -58,10 +60,12 @@ def extract_images(content_parts: Any) -> list[dict[str, Any]]:
                     if isinstance(sub, dict) and sub.get("type") == "image":
                         source = sub.get("source", {})
                         if source.get("type") == "base64" and source.get("data"):
-                            images.append({
-                                "media_type": source.get("media_type", "image/png"),
-                                "data": source["data"],
-                            })
+                            images.append(
+                                {
+                                    "media_type": source.get("media_type", "image/png"),
+                                    "data": source["data"],
+                                }
+                            )
     return images
 
 
@@ -85,8 +89,12 @@ def strip_system_tags(text: str) -> str:
     ide_opened_file, etc.) so exported text is clean."""
     # Remove block tags and their content
     for tag in (
-        "system-reminder", "ide_opened_file", "user-prompt-submit-hook",
-        "claude_background_info", "fast_mode_info", "env",
+        "system-reminder",
+        "ide_opened_file",
+        "user-prompt-submit-hook",
+        "claude_background_info",
+        "fast_mode_info",
+        "env",
     ):
         text = re.sub(rf"<{tag}>[\s\S]*?</{tag}>", "", text)
     # Strip remaining known opening/closing tags

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -9,10 +9,20 @@ from typing import Any
 from models.session import MessageDict, SessionDict
 from utils.jsonl_helpers import (
     entry_message as _entry_message,
+)
+from utils.jsonl_helpers import (
     extract_images as _extract_images,
+)
+from utils.jsonl_helpers import (
     extract_text as _extract_text,
+)
+from utils.jsonl_helpers import (
     infer_title as _infer_title,
+)
+from utils.jsonl_helpers import (
     normalize_content as _normalize_content,
+)
+from utils.jsonl_helpers import (
     strip_system_tags as _strip_system_tags,
 )
 from utils.session_peek import quick_session_info

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -9,20 +9,10 @@ from typing import Any
 from models.session import MessageDict, SessionDict
 from utils.jsonl_helpers import (
     entry_message as _entry_message,
-)
-from utils.jsonl_helpers import (
     extract_images as _extract_images,
-)
-from utils.jsonl_helpers import (
     extract_text as _extract_text,
-)
-from utils.jsonl_helpers import (
     infer_title as _infer_title,
-)
-from utils.jsonl_helpers import (
     normalize_content as _normalize_content,
-)
-from utils.jsonl_helpers import (
     strip_system_tags as _strip_system_tags,
 )
 from utils.session_peek import quick_session_info
@@ -145,15 +135,9 @@ def parse_session(filepath: str) -> SessionDict:
     # Compute wall clock time
     if metadata["first_timestamp"] and metadata["last_timestamp"]:
         try:
-            t0 = datetime.fromisoformat(
-                metadata["first_timestamp"].replace("Z", "+00:00")
-            )
-            t1 = datetime.fromisoformat(
-                metadata["last_timestamp"].replace("Z", "+00:00")
-            )
-            metadata["session_wall_time_seconds"] = max(
-                0, (t1 - t0).total_seconds()
-            )
+            t0 = datetime.fromisoformat(metadata["first_timestamp"].replace("Z", "+00:00"))
+            t1 = datetime.fromisoformat(metadata["last_timestamp"].replace("Z", "+00:00"))
+            metadata["session_wall_time_seconds"] = max(0, (t1 - t0).total_seconds())
         except (ValueError, AttributeError):
             pass
 
@@ -199,18 +183,20 @@ def _process_user(
             if tr_images:
                 images = (images or []) + tr_images
 
-    messages.append({
-        "role": "user",
-        "uuid": entry.get("uuid"),
-        "parent_uuid": entry.get("parentUuid"),
-        "timestamp": entry.get("timestamp"),
-        "text": text,
-        "images": images if images else None,
-        "is_sidechain": entry.get("isSidechain", False),
-        "tool_result": tool_result,
-        "tool_result_parsed": tool_result_parsed,
-        "slug": entry.get("slug"),
-    })
+    messages.append(
+        {
+            "role": "user",
+            "uuid": entry.get("uuid"),
+            "parent_uuid": entry.get("parentUuid"),
+            "timestamp": entry.get("timestamp"),
+            "text": text,
+            "images": images if images else None,
+            "is_sidechain": entry.get("isSidechain", False),
+            "tool_result": tool_result,
+            "tool_result_parsed": tool_result_parsed,
+            "slug": entry.get("slug"),
+        }
+    )
 
 
 def _process_assistant(
@@ -233,9 +219,7 @@ def _process_assistant(
     metadata["total_input_tokens"] += usage.get("input_tokens") or 0
     metadata["total_output_tokens"] += usage.get("output_tokens") or 0
     metadata["total_cache_read_tokens"] += usage.get("cache_read_input_tokens") or 0
-    metadata["total_cache_creation_tokens"] += (
-        usage.get("cache_creation_input_tokens") or 0
-    )
+    metadata["total_cache_creation_tokens"] += usage.get("cache_creation_input_tokens") or 0
 
     # Extended cache metrics
     cache_creation = usage.get("cache_creation", {})
@@ -255,9 +239,7 @@ def _process_assistant(
     # Stop reason tracking
     stop_reason = msg.get("stop_reason", "")
     if stop_reason:
-        metadata["stop_reasons"][stop_reason] = (
-            metadata["stop_reasons"].get(stop_reason, 0) + 1
-        )
+        metadata["stop_reasons"][stop_reason] = metadata["stop_reasons"].get(stop_reason, 0) + 1
 
     content_parts = _normalize_content(msg.get("content", []))
     text_parts = []
@@ -277,35 +259,39 @@ def _process_assistant(
             metadata["tool_call_counts"][tool_name] = (
                 metadata["tool_call_counts"].get(tool_name, 0) + 1
             )
-            tool_uses.append({
-                "id": part.get("id"),
-                "name": tool_name,
-                "input": tool_input,
-            })
+            tool_uses.append(
+                {
+                    "id": part.get("id"),
+                    "name": tool_name,
+                    "input": tool_input,
+                }
+            )
             # Track file activity from tool inputs
             safe_input = tool_input if isinstance(tool_input, dict) else {}
             _track_file_activity(tool_name, safe_input, metadata)
 
-    messages.append({
-        "role": "assistant",
-        "uuid": entry.get("uuid"),
-        "parent_uuid": entry.get("parentUuid"),
-        "timestamp": entry.get("timestamp"),
-        "model": model,
-        "stop_reason": stop_reason,
-        "text": "\n".join(text_parts),
-        "thinking": "\n\n".join(thinking_parts) if thinking_parts else None,
-        "tool_uses": tool_uses if tool_uses else None,
-        "is_sidechain": entry.get("isSidechain", False),
-        "is_api_error": entry.get("isApiErrorMessage", False),
-        "usage": {
-            "input_tokens": usage.get("input_tokens") or 0,
-            "output_tokens": usage.get("output_tokens") or 0,
-            "cache_read": usage.get("cache_read_input_tokens") or 0,
-            "cache_creation": usage.get("cache_creation_input_tokens") or 0,
-            "service_tier": usage.get("service_tier"),
-        },
-    })
+    messages.append(
+        {
+            "role": "assistant",
+            "uuid": entry.get("uuid"),
+            "parent_uuid": entry.get("parentUuid"),
+            "timestamp": entry.get("timestamp"),
+            "model": model,
+            "stop_reason": stop_reason,
+            "text": "\n".join(text_parts),
+            "thinking": "\n\n".join(thinking_parts) if thinking_parts else None,
+            "tool_uses": tool_uses if tool_uses else None,
+            "is_sidechain": entry.get("isSidechain", False),
+            "is_api_error": entry.get("isApiErrorMessage", False),
+            "usage": {
+                "input_tokens": usage.get("input_tokens") or 0,
+                "output_tokens": usage.get("output_tokens") or 0,
+                "cache_read": usage.get("cache_read_input_tokens") or 0,
+                "cache_creation": usage.get("cache_creation_input_tokens") or 0,
+                "service_tier": usage.get("service_tier"),
+            },
+        }
+    )
 
 
 def _process_system(
@@ -318,21 +304,25 @@ def _process_system(
         metadata["compactions"] += 1
         compact_meta = entry.get("compactMetadata")
         if isinstance(compact_meta, dict):
-            metadata["compact_boundaries"].append({
-                "timestamp": entry.get("timestamp"),
-                "trigger": compact_meta.get("trigger"),
-                "pre_tokens": compact_meta.get("preTokens"),
-            })
+            metadata["compact_boundaries"].append(
+                {
+                    "timestamp": entry.get("timestamp"),
+                    "trigger": compact_meta.get("trigger"),
+                    "pre_tokens": compact_meta.get("preTokens"),
+                }
+            )
 
-    messages.append({
-        "role": "system",
-        "uuid": entry.get("uuid"),
-        "parent_uuid": entry.get("parentUuid"),
-        "timestamp": entry.get("timestamp"),
-        "subtype": subtype,
-        "content": entry.get("content", ""),
-        "is_sidechain": entry.get("isSidechain", False),
-    })
+    messages.append(
+        {
+            "role": "system",
+            "uuid": entry.get("uuid"),
+            "parent_uuid": entry.get("parentUuid"),
+            "timestamp": entry.get("timestamp"),
+            "subtype": subtype,
+            "content": entry.get("content", ""),
+            "is_sidechain": entry.get("isSidechain", False),
+        }
+    )
 
 
 def _process_progress(entry: dict[str, Any], messages: list[MessageDict]) -> None:
@@ -341,17 +331,19 @@ def _process_progress(entry: dict[str, Any], messages: list[MessageDict]) -> Non
     data = entry.get("data", {})
     progress_type = data.get("type", "")
 
-    messages.append({
-        "role": "progress",
-        "uuid": entry.get("uuid"),
-        "parent_uuid": entry.get("parentUuid"),
-        "timestamp": entry.get("timestamp"),
-        "progress_type": progress_type,
-        "data": data,
-        "tool_use_id": entry.get("toolUseID"),
-        "parent_tool_use_id": entry.get("parentToolUseID"),
-        "is_sidechain": entry.get("isSidechain", False),
-    })
+    messages.append(
+        {
+            "role": "progress",
+            "uuid": entry.get("uuid"),
+            "parent_uuid": entry.get("parentUuid"),
+            "timestamp": entry.get("timestamp"),
+            "progress_type": progress_type,
+            "data": data,
+            "tool_use_id": entry.get("toolUseID"),
+            "parent_tool_use_id": entry.get("parentToolUseID"),
+            "is_sidechain": entry.get("isSidechain", False),
+        }
+    )
 
 
 def _track_file_activity(

--- a/utils/md_exporter.py
+++ b/utils/md_exporter.py
@@ -2,7 +2,6 @@
 (cost, files touched, commands run), and the full conversation."""
 
 from datetime import datetime
-
 from typing import Any
 
 from models.session import MessageDict, SessionDict
@@ -399,7 +398,8 @@ def _render_tool_result(parsed: dict[str, Any]) -> str:
         dur = parsed.get("total_duration_ms")
         dur_str = f" ({dur / 1000:.1f}s)" if dur else ""
         tok_str = f", {parsed['total_tokens']:,} tokens" if parsed.get("total_tokens") else ""
-        tool_str = f", {parsed['total_tool_use_count']} tool calls" if parsed.get("total_tool_use_count") else ""
+        tool_count = parsed.get("total_tool_use_count")
+        tool_str = f", {tool_count} tool calls" if tool_count else ""
         if parsed.get("retrieval_status"):
             lines.append(f"\n**Task retrieval:** {parsed['retrieval_status']}")
         elif parsed.get("description"):
@@ -436,7 +436,7 @@ def _render_system(msg: MessageDict) -> str:
     content = msg.get("content", "")
 
     if subtype == "compact_boundary":
-        lines.append(f"\n*--- Context compacted ---*\n")
+        lines.append("\n*--- Context compacted ---*\n")
     elif content:
         lines.append(f"\n*[System: {content}]*\n")
 

--- a/utils/md_exporter.py
+++ b/utils/md_exporter.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from models.session import MessageDict, SessionDict
 from models.stats import SessionStatsDict
+from utils.session_stats import format_duration
 
 
 def session_to_markdown(session: SessionDict, stats: SessionStatsDict | None = None) -> str:
@@ -25,7 +26,7 @@ def session_to_markdown(session: SessionDict, stats: SessionStatsDict | None = N
 def _build_frontmatter(session: SessionDict) -> str:
     meta = session["metadata"]
     lines = ["---"]
-    lines.append(f"title: \"{_escape_yaml(session['title'])}\"")
+    lines.append(f'title: "{_escape_yaml(session["title"])}"')
     if meta["first_timestamp"]:
         lines.append(f"created: {meta['first_timestamp']}")
     if meta["last_timestamp"]:
@@ -41,18 +42,14 @@ def _build_frontmatter(session: SessionDict) -> str:
     lines.append(f"total_tool_calls: {meta['total_tool_calls']}")
     if meta["tool_call_counts"]:
         lines.append("tool_call_breakdown:")
-        for tool, count in sorted(
-            meta["tool_call_counts"].items(), key=lambda x: -x[1]
-        ):
+        for tool, count in sorted(meta["tool_call_counts"].items(), key=lambda x: -x[1]):
             lines.append(f"  {tool}: {count}")
     if meta.get("stop_reasons"):
         lines.append("stop_reasons:")
-        for reason, count in sorted(
-            meta["stop_reasons"].items(), key=lambda x: -x[1]
-        ):
+        for reason, count in sorted(meta["stop_reasons"].items(), key=lambda x: -x[1]):
             lines.append(f"  {reason}: {count}")
     if meta["cwd"]:
-        lines.append(f"working_directory: \"{_escape_yaml(meta['cwd'])}\"")
+        lines.append(f'working_directory: "{_escape_yaml(meta["cwd"])}"')
     if meta["git_branch"]:
         lines.append(f"git_branch: {meta['git_branch']}")
     if meta["version"]:
@@ -104,8 +101,7 @@ def _build_header(session: SessionDict) -> str:
         parts.append(f"Tool calls: {meta['total_tool_calls']}")
     wall = meta.get("session_wall_time_seconds")
     if wall is not None:
-        from utils.session_stats import _format_duration
-        dur = _format_duration(wall)
+        dur = format_duration(wall)
         if dur:
             parts.append(f"Duration: {dur}")
 
@@ -213,6 +209,7 @@ def _render_user(msg: MessageDict) -> str:
 
     if msg.get("text"):
         from utils.jsonl_parser import _strip_system_tags
+
         lines.append(_strip_system_tags(msg["text"]))
 
     # Render structured tool result instead of raw dump
@@ -259,10 +256,11 @@ def _render_assistant(msg: MessageDict) -> str:
 
     if msg.get("text"):
         from utils.jsonl_parser import _strip_system_tags
+
         lines.append(_strip_system_tags(msg["text"]))
 
     for tool in msg.get("tool_uses") or []:
-            lines.append(_render_tool_use(tool))
+        lines.append(_render_tool_use(tool))
 
     lines.append("\n---\n")
     return "\n".join(lines)
@@ -312,9 +310,7 @@ def _render_tool_use(tool: dict[str, Any]) -> str:
         todos = inp.get("todos", [])
         for t in todos:
             status = t.get("status", "")
-            icon = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}.get(
-                status, "[ ]"
-            )
+            icon = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}.get(status, "[ ]")
             lines.append(f"> - {icon} {t.get('content', '')}")
     elif name == "AskUserQuestion":
         questions = inp.get("questions", [])

--- a/utils/session_path.py
+++ b/utils/session_path.py
@@ -43,34 +43,31 @@ def list_projects(base_dir: str | None = None) -> list[ProjectDict]:
         if not os.path.isdir(project_dir):
             continue
         jsonl_files = [
-            f for f in os.listdir(project_dir)
-            if f.endswith(".jsonl") and not f.startswith(".")
+            f for f in os.listdir(project_dir) if f.endswith(".jsonl") and not f.startswith(".")
         ]
         if jsonl_files:
             latest_mtime = max(
-                os.path.getmtime(os.path.join(project_dir, jf))
-                for jf in jsonl_files
+                os.path.getmtime(os.path.join(project_dir, jf)) for jf in jsonl_files
             )
             from datetime import datetime, timezone
-            last_modified = datetime.fromtimestamp(
-                latest_mtime, tz=timezone.utc
-            ).isoformat()
+
+            last_modified = datetime.fromtimestamp(latest_mtime, tz=timezone.utc).isoformat()
             # Read cwd from sessions to get the real project path
             display_name = name
             for jf in jsonl_files:
-                candidate = _get_display_name(
-                    os.path.join(project_dir, jf), None
-                )
+                candidate = _get_display_name(os.path.join(project_dir, jf), None)
                 if candidate is not None:
                     display_name = candidate
                     break
-            projects.append({
-                "name": name,
-                "path": project_dir,
-                "display_name": display_name,
-                "session_count": len(jsonl_files),
-                "last_modified": last_modified,
-            })
+            projects.append(
+                {
+                    "name": name,
+                    "path": project_dir,
+                    "display_name": display_name,
+                    "session_count": len(jsonl_files),
+                    "last_modified": last_modified,
+                }
+            )
     return projects
 
 
@@ -93,9 +90,7 @@ def _get_display_name(jsonl_path: str, fallback: str | None) -> str | None:
                     out = folder[:1].upper() + folder[1:] if folder else cwd
                     return str(out)
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
-        _logger.warning(
-            "Failed to extract display name from %s: %s", jsonl_path, exc
-        )
+        _logger.warning("Failed to extract display name from %s: %s", jsonl_path, exc)
     return fallback
 
 
@@ -111,10 +106,12 @@ def list_sessions(project_dir: str) -> list[SessionListItemDict]:
         fpath = os.path.join(project_dir, fname)
         session_id = fname.replace(".jsonl", "")
         stat = os.stat(fpath)
-        sessions.append({
-            "id": session_id,
-            "path": fpath,
-            "size_bytes": stat.st_size,
-            "modified": stat.st_mtime,
-        })
+        sessions.append(
+            {
+                "id": session_id,
+                "path": fpath,
+                "size_bytes": stat.st_size,
+                "modified": stat.st_mtime,
+            }
+        )
     return sessions

--- a/utils/session_stats.py
+++ b/utils/session_stats.py
@@ -29,9 +29,7 @@ def compute_stats(session: SessionDict) -> SessionStatsDict:
         "urls_accessed": list(meta.get("web_fetches", [])),
         "conversation_turns": _count_turns(messages),
         "wall_clock_seconds": meta.get("session_wall_time_seconds"),
-        "wall_clock_display": _format_duration(
-            meta.get("session_wall_time_seconds")
-        ),
+        "wall_clock_display": _format_duration(meta.get("session_wall_time_seconds")),
         "cost_estimate_usd": _estimate_cost(messages, meta),
         "tool_result_summary": _summarize_tool_results(messages),
         "stop_reason_summary": dict(meta.get("stop_reasons", {})),
@@ -79,17 +77,15 @@ def _compute_commands_run(messages: list[MessageDict]) -> list[dict[str, Any]]:
         # Match tool results back to commands
         trp = msg.get("tool_result_parsed")
         if msg["role"] == "user" and trp and trp.get("result_type") == "bash":
-                # Try to find matching command by sequential order
-                if pending_commands:
-                    first_id = next(iter(pending_commands))
-                    entry = pending_commands.pop(first_id)
-                    entry["exit_code"] = trp.get("exit_code")
-                    entry["is_error"] = trp.get("is_error", False)
-                    entry["interrupted"] = trp.get("interrupted", False)
-                    entry["return_code_interpretation"] = trp.get(
-                        "return_code_interpretation"
-                    )
-                    commands.append(entry)
+            # Try to find matching command by sequential order
+            if pending_commands:
+                first_id = next(iter(pending_commands))
+                entry = pending_commands.pop(first_id)
+                entry["exit_code"] = trp.get("exit_code")
+                entry["is_error"] = trp.get("is_error", False)
+                entry["interrupted"] = trp.get("interrupted", False)
+                entry["return_code_interpretation"] = trp.get("return_code_interpretation")
+                commands.append(entry)
 
     # Add any unmatched commands (no result captured)
     for entry in pending_commands.values():

--- a/utils/tool_dispatch.py
+++ b/utils/tool_dispatch.py
@@ -31,9 +31,7 @@ def _tool_result_build_bash(tr: dict[str, Any], base: dict[str, Any]) -> dict[st
 
 
 def _tool_result_pred_file_edit(tr: dict[str, Any]) -> bool:
-    return "structuredPatch" in tr or (
-        "filePath" in tr and "newString" in tr
-    )
+    return "structuredPatch" in tr or ("filePath" in tr and "newString" in tr)
 
 
 def _tool_result_build_file_edit(tr: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
@@ -250,9 +248,7 @@ _TOOL_RESULT_DISPATCH = (
 )
 
 
-def _parse_tool_result(
-    tool_result: Any, slug: str | None = None
-) -> dict[str, Any] | None:
+def _parse_tool_result(tool_result: Any, slug: str | None = None) -> dict[str, Any] | None:
     """Figure out what kind of tool result this is (bash, file edit, glob, etc.)
     by looking at which keys are present, since the JSONL doesn't always tag them.
 

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -31,9 +31,7 @@ def _require_value(
     if val is None:
         raise SessionValidationError(path, "must not be null")
     if not isinstance(val, expected_type):
-        raise SessionValidationError(
-            path, f"expected {type_label}, got {type(val).__name__}"
-        )
+        raise SessionValidationError(path, f"expected {type_label}, got {type(val).__name__}")
     return val
 
 


### PR DESCRIPTION
Closes #67 

## Summary

- Add `ruff check` and `pip-audit` CI job on `ubuntu-latest` and `windows-latest`
- Configure ruff (E, F, W, I) in `pyproject.toml`; add `ruff` and `pip-audit` to `requirements-dev.txt`
- Fix existing ruff violations across `api/`, `utils/`, `scripts/`, and `tests/` (no blanket `# noqa`)
- Add `SECURITY.md` with GHSA reporting path, response timeline, and attack-surface scope
- Link `SECURITY.md` from `README.md`; update CI section in README

## Test plan

- [ ] `ruff check .` passes locally
- [ ] `pip-audit -r requirements.txt` passes locally
- [ ] `pytest -q`, `mypy`, and `npm test` pass locally
- [ ] CI matrix green on `ubuntu-latest` and `windows-latest`
- [ ] Enable private vulnerability reporting on GitHub (Settings → Security) or note admin blocker in PR

## Notes

- `pip-audit` scans production `requirements.txt` only (Flask + transitive deps)
- Pre-release policy: security fixes on latest `master` only (`0.1.0.dev0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repository security policy with reporting guidance and response timelines

* **Chores**
  * CI expanded to run linting and dependency security audits on Ubuntu and Windows
  * Added development tooling/configuration for linting and auditing

* **Documentation**
  * README and CONTRIBUTING updated to document dual-platform CI, lint/audit gates, and link to the new security policy

* **Tests**
  * Added/adjusted tests including an exclusion-rule session-stats check ensuring excluded sessions return 404
<!-- end of auto-generated comment: release notes by coderabbit.ai -->