### PR TITLE
feat: narrow MessageDict.role to RoleLiteral

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,6 +8,7 @@ from models.search import SearchHitDict
 from models.session import (
     MessageDict,
     QuickSessionInfoDict,
+    RoleLiteral,
     SessionDict,
     SessionMetadataDict,
     ToolUseDict,
@@ -23,6 +24,7 @@ __all__ = [
     "ProjectDict",
     "ProjectSessionRowDict",
     "QuickSessionInfoDict",
+    "RoleLiteral",
     "SearchHitDict",
     "SessionDict",
     "SessionListItemDict",

--- a/models/search.py
+++ b/models/search.py
@@ -2,11 +2,13 @@
 
 from typing import TypedDict
 
+from models.session import RoleLiteral
+
 
 class SearchHitDict(TypedDict):
     project: str
     session_id: str
     title: str
-    role: str
+    role: RoleLiteral
     timestamp: str | None
     snippet: str

--- a/models/session.py
+++ b/models/session.py
@@ -5,6 +5,8 @@ from typing import Any, Literal, NotRequired, TypedDict
 from models.record_data import RecordDataUnion
 from models.tool_results import ToolNameLiteral, ToolResultUnion
 
+RoleLiteral = Literal["user", "assistant", "system", "result", "progress"]
+
 
 class ToolUseDict(TypedDict, total=False):
     id: str
@@ -25,7 +27,7 @@ SystemSubtypeLiteral = Literal["compact_boundary", "init"]
 
 
 class MessageDict(TypedDict):
-    role: str
+    role: RoleLiteral
     uuid: NotRequired[str | None]
     parent_uuid: NotRequired[str | None]
     timestamp: NotRequired[str | None]

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -988,13 +988,31 @@ class TestUnknownRoleCoercion:
             ]
         )
         try:
-            with caplog.at_level("WARNING"):
+            with caplog.at_level("WARNING", logger="utils.jsonl_parser"):
                 s = parse_session(path)
             assert len(s["messages"]) == 1
             assert s["messages"][0]["role"] == "system"
+            assert s["messages"][0]["text"] == "forward-compat payload"
             assert s["messages"][0]["content"] == "forward-compat payload"
             assert "Unknown message role" in caplog.text
             assert "mystery_future_type" in caplog.text
+        finally:
+            os.unlink(path)
+
+    def test_fallback_message_extracts_text_from_structured_content(self):
+        path = _write_jsonl(
+            [
+                {
+                    "type": "result",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "content": [{"type": "text", "text": "block body"}],
+                }
+            ]
+        )
+        try:
+            s = parse_session(path)
+            assert s["messages"][0]["text"] == "block body"
+            assert s["messages"][0]["content"] == "block body"
         finally:
             os.unlink(path)
 
@@ -1014,3 +1032,19 @@ class TestUnknownRoleCoercion:
             assert s["messages"][0]["role"] == "result"
         finally:
             os.unlink(path)
+
+
+class TestCoerceRole:
+    def test_known_roles_returned_unchanged(self):
+        from utils.jsonl_parser import _coerce_role
+
+        for role in ("user", "assistant", "system", "result", "progress"):
+            assert _coerce_role(role) == role
+
+    def test_unknown_role_maps_to_system_with_warning(self, caplog):
+        from utils.jsonl_parser import _coerce_role
+
+        with caplog.at_level("WARNING", logger="utils.jsonl_parser"):
+            result = _coerce_role("totally_unknown")
+        assert result == "system"
+        assert "totally_unknown" in caplog.text

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -686,22 +686,6 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
-    def test_unknown_entry_type_maps_to_system(self, caplog):
-        path = _write_jsonl(
-            [
-                {"type": "custom", "timestamp": "2026-01-01T00:00:00Z"},
-            ]
-        )
-        try:
-            with caplog.at_level("WARNING"):
-                s = parse_session(path)
-            assert len(s["messages"]) == 1
-            assert s["messages"][0]["role"] == "system"
-            assert s["metadata"]["entry_counts"].get("custom") == 1
-            assert "Unknown message role" in caplog.text
-        finally:
-            os.unlink(path)
-
     def test_is_sidechain_increments_counter(self):
         path = _write_jsonl(
             [
@@ -732,6 +716,7 @@ class TestParseSession:
             s = parse_session(path)
             assert s["metadata"]["first_timestamp"] == "2026-01-02T12:00:00Z"
             assert s["metadata"]["last_timestamp"] == "2026-01-02T12:00:00Z"
+            assert len(s["messages"]) == 0
         finally:
             os.unlink(path)
 

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -686,16 +686,19 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
-    def test_unknown_entry_type_silently_ignored(self):
+    def test_unknown_entry_type_maps_to_system(self, caplog):
         path = _write_jsonl(
             [
                 {"type": "custom", "timestamp": "2026-01-01T00:00:00Z"},
             ]
         )
         try:
-            s = parse_session(path)
-            assert s["messages"] == []
+            with caplog.at_level("WARNING"):
+                s = parse_session(path)
+            assert len(s["messages"]) == 1
+            assert s["messages"][0]["role"] == "system"
             assert s["metadata"]["entry_counts"].get("custom") == 1
+            assert "Unknown message role" in caplog.text
         finally:
             os.unlink(path)
 
@@ -981,3 +984,48 @@ class TestMalformedPartialEntries:
             ]
         )
         assert s["messages"][0]["tool_result_parsed"] is None
+
+
+# ---------------------------------------------------------------------------
+# Unknown role coercion
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownRoleCoercion:
+    def test_unknown_entry_type_maps_to_system_with_warning(self, caplog):
+        path = _write_jsonl(
+            [
+                {
+                    "type": "mystery_future_type",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "content": "forward-compat payload",
+                }
+            ]
+        )
+        try:
+            with caplog.at_level("WARNING"):
+                s = parse_session(path)
+            assert len(s["messages"]) == 1
+            assert s["messages"][0]["role"] == "system"
+            assert s["messages"][0]["content"] == "forward-compat payload"
+            assert "Unknown message role" in caplog.text
+            assert "mystery_future_type" in caplog.text
+        finally:
+            os.unlink(path)
+
+    def test_valid_unhandled_result_type_emits_result_role(self):
+        path = _write_jsonl(
+            [
+                {
+                    "type": "result",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "content": "task outcome",
+                }
+            ]
+        )
+        try:
+            s = parse_session(path)
+            assert len(s["messages"]) == 1
+            assert s["messages"][0]["role"] == "result"
+        finally:
+            os.unlink(path)

--- a/tests/test_jsonl_parser.py
+++ b/tests/test_jsonl_parser.py
@@ -720,6 +720,25 @@ class TestParseSession:
         finally:
             os.unlink(path)
 
+    def test_summary_entry_type_produces_no_message(self, caplog):
+        path = _write_jsonl(
+            [
+                {
+                    "type": "summary",
+                    "timestamp": "2026-01-03T08:00:00Z",
+                    "summary": "Session recap metadata",
+                },
+            ]
+        )
+        try:
+            with caplog.at_level("WARNING", logger="utils.jsonl_parser"):
+                s = parse_session(path)
+            assert len(s["messages"]) == 0
+            assert s["metadata"]["entry_counts"].get("summary") == 1
+            assert "Unknown message role" not in caplog.text
+        finally:
+            os.unlink(path)
+
     def test_entry_counts_accumulated(self):
         assistant_entry = {
             "type": "assistant",

--- a/tests/test_jsonl_validation.py
+++ b/tests/test_jsonl_validation.py
@@ -70,6 +70,12 @@ class TestValidateSessionDict:
         assert result["session_id"] == "abc123"
         assert result["messages"][0]["role"] == "user"
 
+    def test_invalid_role_in_message(self):
+        with pytest.raises(SessionValidationError) as exc_info:
+            validate_session_dict(_valid_payload(messages=[{"role": "custom", "text": "x"}]))
+        assert exc_info.value.path == "messages[0].role"
+        assert "custom" in exc_info.value.detail
+
 
 class TestParseSessionValidationRegression:
     def test_session_minimal_fixture_unchanged(self):

--- a/tests/test_parser_fuzz.py
+++ b/tests/test_parser_fuzz.py
@@ -240,8 +240,10 @@ def test_unknown_record_type_is_graceful(tmp_path: Path) -> None:
     path = _write_jsonl(tmp_path / "unknown.jsonl", lines)
     session = parse_session(path)
     assert session["metadata"]["entry_counts"].get("totally-new-claude-record") == 1
-    # Unknown type produces no message; only the valid user line does.
-    assert len(session["messages"]) == 1
+    # Unknown type is coerced to a system message; the valid user line follows.
+    assert len(session["messages"]) == 2
+    assert session["messages"][0]["role"] == "system"
+    assert session["messages"][1]["role"] == "user"
 
 
 def test_non_numeric_usage_tokens_do_not_crash(tmp_path: Path) -> None:

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -25,6 +25,7 @@ from utils.validation import validate_session_dict
 __all__ = ["parse_session", "quick_session_info"]
 
 _HANDLED_ENTRY_TYPES = frozenset({"user", "assistant", "system", "progress"})
+_SKIP_ENTRY_TYPES = frozenset({"file-history-snapshot"})
 _VALID_ROLES = frozenset(get_args(RoleLiteral))
 
 
@@ -154,7 +155,7 @@ def parse_session(filepath: str) -> SessionDict:
                 _process_progress(entry, messages)
             elif entry_type:
                 type_str = entry_type if isinstance(entry_type, str) else str(entry_type)
-                if type_str not in _HANDLED_ENTRY_TYPES:
+                if type_str not in _HANDLED_ENTRY_TYPES and type_str not in _SKIP_ENTRY_TYPES:
                     messages.append(_fallback_message(entry, _coerce_role(type_str)))
 
     metadata["models_used"] = sorted(metadata["models_used"])

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -24,7 +24,8 @@ from utils.validation import validate_session_dict
 
 __all__ = ["parse_session", "quick_session_info"]
 
-_SKIP_ENTRY_TYPES = frozenset({"file-history-snapshot"})
+# Metadata-only JSONL entry types: contribute timestamps/counts but not messages.
+_SKIP_ENTRY_TYPES = frozenset({"file-history-snapshot", "summary"})
 _VALID_ROLES = frozenset(get_args(RoleLiteral))
 _log = logging.getLogger(__name__)
 

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -24,27 +24,33 @@ from utils.validation import validate_session_dict
 
 __all__ = ["parse_session", "quick_session_info"]
 
-_HANDLED_ENTRY_TYPES = frozenset({"user", "assistant", "system", "progress"})
 _SKIP_ENTRY_TYPES = frozenset({"file-history-snapshot"})
 _VALID_ROLES = frozenset(get_args(RoleLiteral))
+_log = logging.getLogger(__name__)
 
 
 def _coerce_role(raw: str) -> RoleLiteral:
     if raw in _VALID_ROLES:
         return cast(RoleLiteral, raw)
-    logging.warning("Unknown message role %r; mapping to 'system'", raw)
+    _log.warning("Unknown message role %r; mapping to 'system'", raw)
     return "system"
 
 
 def _fallback_message(entry: dict[str, Any], role: RoleLiteral) -> MessageDict:
     """Minimal message for JSONL entry types without a dedicated processor."""
-    content = entry.get("content", "")
-    text = content if isinstance(content, str) else (str(content) if content is not None else "")
+    raw_content = entry.get("content", "")
+    if isinstance(raw_content, str):
+        text = raw_content
+    elif raw_content is not None:
+        text = _extract_text(_normalize_content(raw_content))
+    else:
+        text = ""
     return {
         "role": role,
         "uuid": entry.get("uuid"),
         "parent_uuid": entry.get("parentUuid"),
         "timestamp": entry.get("timestamp"),
+        "text": text,
         "content": text,
         "is_sidechain": entry.get("isSidechain", False),
     }
@@ -155,7 +161,7 @@ def parse_session(filepath: str) -> SessionDict:
                 _process_progress(entry, messages)
             elif entry_type:
                 type_str = entry_type if isinstance(entry_type, str) else str(entry_type)
-                if type_str not in _HANDLED_ENTRY_TYPES and type_str not in _SKIP_ENTRY_TYPES:
+                if type_str not in _SKIP_ENTRY_TYPES:
                     messages.append(_fallback_message(entry, _coerce_role(type_str)))
 
     metadata["models_used"] = sorted(metadata["models_used"])

--- a/utils/jsonl_parser.py
+++ b/utils/jsonl_parser.py
@@ -2,13 +2,14 @@
 actually work with -- messages, tool calls, token counts, file activity, etc."""
 
 import json
+import logging
 import math
 import os
 from datetime import datetime
-from typing import Any
+from typing import Any, cast, get_args
 
 from models.record_data import RecordDataUnion
-from models.session import MessageDict, SessionDict, ToolUseDict
+from models.session import MessageDict, RoleLiteral, SessionDict, ToolUseDict
 from models.tool_results import ToolResultUnion, is_tool_result_dict
 from utils.jsonl_helpers import (
     entry_message as _entry_message,
@@ -22,6 +23,30 @@ from utils.tool_dispatch import _parse_tool_result
 from utils.validation import validate_session_dict
 
 __all__ = ["parse_session", "quick_session_info"]
+
+_HANDLED_ENTRY_TYPES = frozenset({"user", "assistant", "system", "progress"})
+_VALID_ROLES = frozenset(get_args(RoleLiteral))
+
+
+def _coerce_role(raw: str) -> RoleLiteral:
+    if raw in _VALID_ROLES:
+        return cast(RoleLiteral, raw)
+    logging.warning("Unknown message role %r; mapping to 'system'", raw)
+    return "system"
+
+
+def _fallback_message(entry: dict[str, Any], role: RoleLiteral) -> MessageDict:
+    """Minimal message for JSONL entry types without a dedicated processor."""
+    content = entry.get("content", "")
+    text = content if isinstance(content, str) else (str(content) if content is not None else "")
+    return {
+        "role": role,
+        "uuid": entry.get("uuid"),
+        "parent_uuid": entry.get("parentUuid"),
+        "timestamp": entry.get("timestamp"),
+        "content": text,
+        "is_sidechain": entry.get("isSidechain", False),
+    }
 
 
 def _safe_int(val: Any) -> int:
@@ -127,6 +152,10 @@ def parse_session(filepath: str) -> SessionDict:
                 _process_system(entry, messages, metadata)
             elif entry_type == "progress":
                 _process_progress(entry, messages)
+            elif entry_type:
+                type_str = entry_type if isinstance(entry_type, str) else str(entry_type)
+                if type_str not in _HANDLED_ENTRY_TYPES:
+                    messages.append(_fallback_message(entry, _coerce_role(type_str)))
 
     metadata["models_used"] = sorted(metadata["models_used"])
     metadata["service_tiers"] = sorted(metadata["service_tiers"])

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,9 +1,11 @@
 """Runtime validation for TypedDict shapes at untrusted-data boundaries."""
 
-from typing import Any, cast
+from typing import Any, cast, get_args
 
 from models.errors import SessionValidationError
-from models.session import SessionDict
+from models.session import RoleLiteral, SessionDict
+
+_VALID_ROLES = frozenset(get_args(RoleLiteral))
 
 _ROOT_PATH = "(root)"
 
@@ -49,6 +51,11 @@ def validate_session_dict(data: dict[str, Any]) -> SessionDict:
     for index, message in enumerate(messages):
         path = f"messages[{index}]"
         msg_dict = _require_value(path, message, dict, "dict")
-        _require_field(msg_dict, "role", str, "str", path=f"{path}.role")
+        role = _require_field(msg_dict, "role", str, "str", path=f"{path}.role")
+        if role not in _VALID_ROLES:
+            raise SessionValidationError(
+                f"{path}.role",
+                f"expected one of {sorted(_VALID_ROLES)!r}, got {role!r}",
+            )
 
     return cast(SessionDict, data)


### PR DESCRIPTION
Closes #81

## Summary

- Add `RoleLiteral` in `models/session.py` and narrow `MessageDict.role` from `str` to the literal union (`user`, `assistant`, `system`, `result`, `progress`).
- Propagate the narrowed type to `SearchHitDict.role` in `models/search.py`.
- Add `_coerce_role()` in `utils/jsonl_parser.py`: unknown JSONL entry types map to `"system"` with `logging.warning`, never raise.
- Emit fallback messages for unhandled entry types (including valid `result` entries).
- Export `RoleLiteral` from `models/__init__.py`.
- Add `TestUnknownRoleCoercion` and update tests that previously expected unknown types to be silently skipped.

## Test plan

- [ ] `mypy -p api -p utils -p models`
- [ ] `ruff check .`
- [ ] `pytest tests/test_jsonl_parser.py -q`
- [ ] `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter role handling: session messages now only allow predefined roles (user, assistant, system, result, progress), enforced with runtime validation that rejects invalid roles.
  * Improved JSONL robustness: non-standard/unknown entry types are coerced into `system` messages with warnings, including safer fallback extraction and correct behavior for `result` and `summary`.
* **Bug Fixes**
  * Unknown record/type parsing now produces the expected additional coerced `system` message instead of skipping.
* **Tests**
  * Expanded fuzzing and parser/validation coverage, including structured-content fallback behavior and precise validation error-path assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->