### PR TITLE
perf: add mtime-invalidated LRU session cache; route APIs through it

### DIFF
--- a/api/export_api.py
+++ b/api/export_api.py
@@ -26,8 +26,8 @@ from utils.export_state_store import (
     load_export_state_from_disk,
 )
 from utils.json_exporter import session_to_json
-from utils.jsonl_parser import parse_session
 from utils.md_exporter import session_to_markdown
+from utils.session_cache import get_cached_session
 from utils.session_path import get_claude_projects_dir, list_projects, safe_join
 from utils.session_stats import compute_stats
 from utils.slugify import slugify
@@ -237,7 +237,7 @@ def export_session(project_name: str, session_id: str) -> FlaskReturn:
 
     fmt = request.args.get("format", "md")
     try:
-        session = parse_session(filepath)
+        session = get_cached_session(filepath)
     except _EXPORT_ERRORS:
         current_app.logger.exception("Failed to parse session %s for export", session_id)
         return error_response(

--- a/api/projects.py
+++ b/api/projects.py
@@ -7,6 +7,7 @@ from api.error_codes import ErrorCode, error_response
 from models.project import ProjectSessionRowDict, SessionListItemDict
 from models.session import SessionDict
 from utils.exclusion_rules import is_session_excluded
+from utils.session_cache import get_cached_session
 from utils.session_path import get_claude_projects_dir, list_projects, list_sessions, safe_join
 
 projects_bp = Blueprint("projects", __name__)
@@ -80,9 +81,6 @@ def get_project_sessions(project_name: str) -> FlaskReturn:
     except ValueError:
         return error_response(ErrorCode.INVALID_PATH, "Invalid path", 400)
     sessions = list_sessions(project_dir)
-    # Add summary preview for each session
-    from utils.session_cache import get_cached_session
-
     rules = current_app.config.get("EXCLUSION_RULES") or []
     result: list[ProjectSessionRowDict] = []
     for s in sessions:

--- a/api/projects.py
+++ b/api/projects.py
@@ -81,13 +81,13 @@ def get_project_sessions(project_name: str) -> FlaskReturn:
         return error_response(ErrorCode.INVALID_PATH, "Invalid path", 400)
     sessions = list_sessions(project_dir)
     # Add summary preview for each session
-    from utils.jsonl_parser import parse_session
+    from utils.session_cache import get_cached_session
 
     rules = current_app.config.get("EXCLUSION_RULES") or []
     result: list[ProjectSessionRowDict] = []
     for s in sessions:
         try:
-            parsed = parse_session(s["path"])
+            parsed = get_cached_session(s["path"])
             # Skip untitled sessions (no real conversation)
             if parsed["title"] == "Untitled Session":
                 continue

--- a/api/search.py
+++ b/api/search.py
@@ -6,7 +6,7 @@ from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from models.search import SearchHitDict
 from utils.exclusion_rules import is_session_excluded
-from utils.jsonl_parser import parse_session
+from utils.session_cache import get_cached_session
 from utils.session_path import get_claude_projects_dir, list_projects, list_sessions
 
 search_bp = Blueprint("search", __name__)
@@ -54,7 +54,7 @@ def search() -> FlaskReturn:
             if len(results) >= max_results:
                 break
             try:
-                session = parse_session(sess_info["path"])
+                session = get_cached_session(sess_info["path"])
             except Exception:
                 continue
 

--- a/api/search.py
+++ b/api/search.py
@@ -49,6 +49,8 @@ def search() -> FlaskReturn:
     rules = current_app.config.get("EXCLUSION_RULES") or []
     results: list[SearchHitDict] = []
     for project in projects:
+        if len(results) >= max_results:
+            break
         sessions = list_sessions(project["path"])
         for sess_info in sessions:
             if len(results) >= max_results:

--- a/api/sessions.py
+++ b/api/sessions.py
@@ -8,7 +8,7 @@ from flask import Blueprint, current_app
 from api._flask_types import FlaskReturn, json_response
 from api.error_codes import ErrorCode, error_response
 from utils.exclusion_rules import is_session_excluded
-from utils.jsonl_parser import parse_session
+from utils.session_cache import get_cached_session
 from utils.session_path import get_claude_projects_dir, safe_join
 from utils.session_stats import compute_stats
 
@@ -39,7 +39,7 @@ def get_session(project_name: str, session_id: str) -> FlaskReturn:
         )
 
     try:
-        session = parse_session(filepath)
+        session = get_cached_session(filepath)
         rules = current_app.config.get("EXCLUSION_RULES") or []
         if is_session_excluded(rules, session, project_name):
             return error_response(
@@ -73,7 +73,7 @@ def get_session_stats(project_name: str, session_id: str) -> FlaskReturn:
         )
 
     try:
-        session = parse_session(filepath)
+        session = get_cached_session(filepath)
         rules = current_app.config.get("EXCLUSION_RULES") or []
         if is_session_excluded(rules, session, project_name):
             return error_response(

--- a/tests/benchmarks/test_cache_bench.py
+++ b/tests/benchmarks/test_cache_bench.py
@@ -17,12 +17,7 @@ def _reset_cache() -> None:
 @pytest.mark.benchmark(group="cache")
 def test_cache_cold_parse(benchmark, parse_medium_file: Path) -> None:
     path = str(parse_medium_file)
-
-    def cold() -> None:
-        clear_cache()
-        get_cached_session(path)
-
-    benchmark(cold)
+    benchmark.pedantic(get_cached_session, args=(path,), setup=clear_cache)
 
 
 @pytest.mark.benchmark(group="cache")

--- a/tests/benchmarks/test_cache_bench.py
+++ b/tests/benchmarks/test_cache_bench.py
@@ -1,0 +1,32 @@
+"""Benchmark cold parse vs warm cache hit for get_cached_session."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils.session_cache import clear_cache, get_cached_session
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    clear_cache()
+
+
+@pytest.mark.benchmark(group="cache")
+def test_cache_cold_parse(benchmark, parse_medium_file: Path) -> None:
+    path = str(parse_medium_file)
+
+    def cold() -> None:
+        clear_cache()
+        get_cached_session(path)
+
+    benchmark(cold)
+
+
+@pytest.mark.benchmark(group="cache")
+def test_cache_warm_hit(benchmark, parse_medium_file: Path) -> None:
+    path = str(parse_medium_file)
+    get_cached_session(path)
+    benchmark(get_cached_session, path)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -66,7 +66,7 @@ def test_session_detail_parse_failure_returns_500_without_leak(client, monkeypat
     def _boom(*_args, **_kwargs):
         raise KeyError("internal_secret_field_id")
 
-    monkeypatch.setattr("api.sessions.parse_session", _boom)
+    monkeypatch.setattr("api.sessions.get_cached_session", _boom)
     resp = client.get("/api/sessions/test-project/session_abc123")
     assert resp.status_code == 500
     body_text = resp.get_data(as_text=True)

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -179,9 +179,7 @@ class TestGetProjectsErrorCard:
         def _boom(*args, **kwargs):
             raise KeyError("internal_secret_field_id")
 
-        # api/projects.py imports parse_session inside the handler body,
-        # so patch the source module rather than the consumer.
-        monkeypatch.setattr("utils.session_cache.get_cached_session", _boom)
+        monkeypatch.setattr("api.projects.get_cached_session", _boom)
 
         resp = client.get("/api/projects/myproj/sessions")
         # Pin the response shape so a future wrapper change (e.g. {"sessions": [...]})

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -109,7 +109,7 @@ class TestGetSessionErrorBody:
         def _boom(*args, **kwargs):
             raise KeyError("internal_secret_field_id")
 
-        monkeypatch.setattr("api.sessions.parse_session", _boom)
+        monkeypatch.setattr("api.sessions.get_cached_session", _boom)
 
         resp = client.get("/api/sessions/proj/abc")
         assert resp.status_code == 500
@@ -151,7 +151,7 @@ class TestGetSessionStatsErrorBody:
         def _boom(*args, **kwargs):
             raise ValueError("invalid literal: '/private/path/secret.json'")
 
-        monkeypatch.setattr("api.sessions.parse_session", _boom)
+        monkeypatch.setattr("api.sessions.get_cached_session", _boom)
 
         resp = client.get("/api/sessions/proj/abc/stats")
         assert resp.status_code == 500
@@ -181,7 +181,7 @@ class TestGetProjectsErrorCard:
 
         # api/projects.py imports parse_session inside the handler body,
         # so patch the source module rather than the consumer.
-        monkeypatch.setattr("utils.jsonl_parser.parse_session", _boom)
+        monkeypatch.setattr("utils.session_cache.get_cached_session", _boom)
 
         resp = client.get("/api/projects/myproj/sessions")
         # Pin the response shape so a future wrapper change (e.g. {"sessions": [...]})

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import os
 import shutil
-import time
 from pathlib import Path
 
 import pytest
@@ -51,10 +51,36 @@ def test_cache_hit_avoids_reparse(sample_session: Path, monkeypatch: pytest.Monk
 def test_cache_invalidates_on_mtime_change(sample_session: Path) -> None:
     path = str(sample_session)
     first = get_cached_session(path)
-    time.sleep(0.05)
-    sample_session.touch()
+    stat = sample_session.stat()
+    os.utime(sample_session, (stat.st_mtime + 1, stat.st_mtime + 1))
     second = get_cached_session(path)
     assert first is not second
+
+
+def test_cache_normalizes_relative_and_absolute_paths(
+    sample_session: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def counting_parse(p: str):
+        nonlocal calls
+        calls += 1
+        return parse_session(p)
+
+    monkeypatch.setattr("utils.session_cache.parse_session", counting_parse)
+    rel = "session.jsonl"
+    abs_path = str(sample_session.resolve())
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        get_cached_session(rel)
+        assert calls == 1
+        get_cached_session(abs_path)
+        assert calls == 1
+    finally:
+        os.chdir(original_cwd)
 
 
 def test_lru_eviction(sample_session: Path, tmp_path: Path) -> None:
@@ -87,3 +113,8 @@ def test_lru_eviction(sample_session: Path, tmp_path: Path) -> None:
         assert calls == 1
     finally:
         monkeypatch.undo()
+
+
+def test_set_max_entries_rejects_negative() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        set_max_entries(-1)

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -128,3 +128,22 @@ def test_lru_eviction(
 def test_set_max_entries_rejects_negative() -> None:
     with pytest.raises(ValueError, match="non-negative"):
         set_max_entries(-1)
+
+
+def test_returns_parsed_when_mtime_after_parse_raises(
+    sample_session: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = str(sample_session)
+    real_getmtime = os.path.getmtime
+    calls = 0
+
+    def getmtime_side_effect(p: str) -> float:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("file removed after parse")
+        return real_getmtime(p)
+
+    monkeypatch.setattr(os.path, "getmtime", getmtime_side_effect)
+    result = get_cached_session(path)
+    assert result == parse_session(path)

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -1,0 +1,89 @@
+"""Unit tests for utils.session_cache."""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from utils.jsonl_parser import parse_session
+from utils.session_cache import clear_cache, get_cached_session, set_max_entries
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SAMPLE_SESSION = FIXTURES / "session_with_tools.jsonl"
+
+
+@pytest.fixture
+def sample_session(tmp_path: Path) -> Path:
+    dest = tmp_path / "session.jsonl"
+    shutil.copy(SAMPLE_SESSION, dest)
+    return dest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    clear_cache()
+    set_max_entries(200)
+
+
+def test_cache_returns_same_data_as_direct_parse(sample_session: Path) -> None:
+    path = str(sample_session)
+    assert get_cached_session(path) == parse_session(path)
+
+
+def test_cache_hit_avoids_reparse(sample_session: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = str(sample_session)
+    get_cached_session(path)
+    calls = 0
+
+    def counting_parse(p: str):
+        nonlocal calls
+        calls += 1
+        return parse_session(p)
+
+    monkeypatch.setattr("utils.session_cache.parse_session", counting_parse)
+    get_cached_session(path)
+    assert calls == 0
+
+
+def test_cache_invalidates_on_mtime_change(sample_session: Path) -> None:
+    path = str(sample_session)
+    first = get_cached_session(path)
+    time.sleep(0.05)
+    sample_session.touch()
+    second = get_cached_session(path)
+    assert first is not second
+
+
+def test_lru_eviction(sample_session: Path, tmp_path: Path) -> None:
+    set_max_entries(2)
+    content = sample_session.read_text(encoding="utf-8")
+    paths = []
+    for name in ("a.jsonl", "b.jsonl", "c.jsonl"):
+        p = tmp_path / name
+        p.write_text(content, encoding="utf-8")
+        paths.append(p)
+
+    for p in paths:
+        get_cached_session(str(p))
+
+    calls = 0
+
+    def counting_parse(p: str):
+        nonlocal calls
+        calls += 1
+        return parse_session(p)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("utils.session_cache.parse_session", counting_parse)
+    try:
+        get_cached_session(str(paths[2]))
+        assert calls == 0
+        get_cached_session(str(paths[1]))
+        assert calls == 0
+        get_cached_session(str(paths[0]))
+        assert calls == 1
+    finally:
+        monkeypatch.undo()

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -48,13 +48,25 @@ def test_cache_hit_avoids_reparse(sample_session: Path, monkeypatch: pytest.Monk
     assert calls == 0
 
 
-def test_cache_invalidates_on_mtime_change(sample_session: Path) -> None:
+def test_cache_invalidates_on_mtime_change(
+    sample_session: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = str(sample_session)
-    first = get_cached_session(path)
+    get_cached_session(path)
+
+    calls = 0
+
+    def counting_parse(p: str):
+        nonlocal calls
+        calls += 1
+        return parse_session(p)
+
+    monkeypatch.setattr("utils.session_cache.parse_session", counting_parse)
+
     stat = sample_session.stat()
     os.utime(sample_session, (stat.st_mtime + 1, stat.st_mtime + 1))
-    second = get_cached_session(path)
-    assert first is not second
+    get_cached_session(path)
+    assert calls == 1
 
 
 def test_cache_normalizes_relative_and_absolute_paths(
@@ -83,7 +95,9 @@ def test_cache_normalizes_relative_and_absolute_paths(
         os.chdir(original_cwd)
 
 
-def test_lru_eviction(sample_session: Path, tmp_path: Path) -> None:
+def test_lru_eviction(
+    sample_session: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     set_max_entries(2)
     content = sample_session.read_text(encoding="utf-8")
     paths = []
@@ -102,17 +116,13 @@ def test_lru_eviction(sample_session: Path, tmp_path: Path) -> None:
         calls += 1
         return parse_session(p)
 
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr("utils.session_cache.parse_session", counting_parse)
-    try:
-        get_cached_session(str(paths[2]))
-        assert calls == 0
-        get_cached_session(str(paths[1]))
-        assert calls == 0
-        get_cached_session(str(paths[0]))
-        assert calls == 1
-    finally:
-        monkeypatch.undo()
+    get_cached_session(str(paths[2]))
+    assert calls == 0
+    get_cached_session(str(paths[1]))
+    assert calls == 0
+    get_cached_session(str(paths[0]))
+    assert calls == 1
 
 
 def test_set_max_entries_rejects_negative() -> None:

--- a/utils/session_cache.py
+++ b/utils/session_cache.py
@@ -32,7 +32,10 @@ def get_cached_session(path: str) -> SessionDict:
             _cache.move_to_end(abspath)
             return hit[1]
     parsed = parse_session(abspath)
-    mtime_after = os.path.getmtime(abspath)
+    try:
+        mtime_after = os.path.getmtime(abspath)
+    except OSError:
+        return parsed
     with _lock:
         if _max_entries > 0 and mtime_after == mtime_before:
             _cache[abspath] = (mtime_after, parsed)

--- a/utils/session_cache.py
+++ b/utils/session_cache.py
@@ -1,0 +1,49 @@
+"""In-memory session parse cache with mtime invalidation and LRU eviction."""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections import OrderedDict
+
+from models.session import SessionDict
+from utils.jsonl_parser import parse_session
+
+DEFAULT_MAX_ENTRIES = 200
+
+_lock = threading.Lock()
+_cache: OrderedDict[str, tuple[float, SessionDict]] = OrderedDict()
+_max_entries = DEFAULT_MAX_ENTRIES
+
+
+def get_cached_session(path: str) -> SessionDict:
+    """Return a parsed session, reusing the cache when mtime is unchanged."""
+    abspath = os.path.abspath(path)
+    mtime = os.path.getmtime(abspath)
+    with _lock:
+        hit = _cache.get(abspath)
+        if hit is not None and hit[0] == mtime:
+            _cache.move_to_end(abspath)
+            return hit[1]
+    parsed = parse_session(abspath)
+    with _lock:
+        _cache[abspath] = (mtime, parsed)
+        _cache.move_to_end(abspath)
+        while len(_cache) > _max_entries:
+            _cache.popitem(last=False)
+    return parsed
+
+
+def clear_cache() -> None:
+    """Clear all cached sessions (for tests and debug)."""
+    with _lock:
+        _cache.clear()
+
+
+def set_max_entries(max_entries: int) -> None:
+    """Override the LRU capacity (primarily for tests)."""
+    global _max_entries
+    with _lock:
+        _max_entries = max_entries
+        while len(_cache) > _max_entries:
+            _cache.popitem(last=False)

--- a/utils/session_cache.py
+++ b/utils/session_cache.py
@@ -17,20 +17,28 @@ _max_entries = DEFAULT_MAX_ENTRIES
 
 
 def get_cached_session(path: str) -> SessionDict:
-    """Return a parsed session, reusing the cache when mtime is unchanged."""
+    """Return a parsed session, reusing the cache when mtime is unchanged.
+
+    Concurrent requests for different paths proceed in parallel.
+    Concurrent misses on the *same* path will each parse independently;
+    the last writer wins. This is safe but may parse the file more than
+    once under high concurrency for a cold key.
+    """
     abspath = os.path.abspath(path)
-    mtime = os.path.getmtime(abspath)
+    mtime_before = os.path.getmtime(abspath)
     with _lock:
         hit = _cache.get(abspath)
-        if hit is not None and hit[0] == mtime:
+        if hit is not None and hit[0] == mtime_before:
             _cache.move_to_end(abspath)
             return hit[1]
     parsed = parse_session(abspath)
+    mtime_after = os.path.getmtime(abspath)
     with _lock:
-        _cache[abspath] = (mtime, parsed)
-        _cache.move_to_end(abspath)
-        while len(_cache) > _max_entries:
-            _cache.popitem(last=False)
+        if _max_entries > 0 and mtime_after == mtime_before:
+            _cache[abspath] = (mtime_after, parsed)
+            _cache.move_to_end(abspath)
+            while len(_cache) > _max_entries:
+                _cache.popitem(last=False)
     return parsed
 
 
@@ -41,7 +49,10 @@ def clear_cache() -> None:
 
 
 def set_max_entries(max_entries: int) -> None:
-    """Override the LRU capacity (primarily for tests)."""
+    """Override the LRU capacity (primarily for tests).
+
+    A value of 0 disables caching entirely — every access will parse from disk.
+    """
     if max_entries < 0:
         raise ValueError(f"max_entries must be non-negative, got {max_entries}")
     global _max_entries

--- a/utils/session_cache.py
+++ b/utils/session_cache.py
@@ -42,6 +42,8 @@ def clear_cache() -> None:
 
 def set_max_entries(max_entries: int) -> None:
     """Override the LRU capacity (primarily for tests)."""
+    if max_entries < 0:
+        raise ValueError(f"max_entries must be non-negative, got {max_entries}")
     global _max_entries
     with _lock:
         _max_entries = max_entries


### PR DESCRIPTION
Closes #82 

## Summary

Adds an mtime-invalidated, LRU-bounded in-memory session cache so repeated API reads stop re-parsing JSONL from disk. Routes all parse-backed API handlers through `get_cached_session()` with no JSON response changes.

Sprint item **#4** (5 pt) — Wednesday PR 1 of 2. Merge before PR 2 (benchmark regression gate #6) so baselines capture cached-path performance.

## Problem

Every session-touching request called `parse_session(filepath)` from disk. `get_session()` and `get_session_stats()` parsed the same file twice; `search()` re-parsed the entire corpus per query. No in-memory cache, no mtime check, no reuse across requests.

## Changes

### New: `utils/session_cache.py`

- Key: absolute file path; value: `(mtime, SessionDict)`
- Invalidate on `os.path.getmtime()` change (edits picked up without restart)
- LRU eviction via `OrderedDict` (default max 200 entries)
- `threading.Lock` for `--debug` reloader / threaded safety
- Parsing happens outside the lock so concurrent misses on different files don't serialize
- Public API: `get_cached_session(path)`, `clear_cache()`, `set_max_entries()` (tests)

### Wired routes

- `api/sessions.py` — `get_session` + `get_session_stats` share one cached parse
- `api/search.py` — per-session loop uses cache (big win for repeated searches)
- `api/projects.py` — `get_project_sessions` uses cache (`get_projects` still uses `quick_session_info`)
- `api/export_api.py` — single-session export uses cache

### Tests & benchmarks

- `tests/test_session_cache.py` — cache hit, mtime invalidation, LRU eviction
- `tests/benchmarks/test_cache_bench.py` — cold parse vs warm hit
- Updated monkeypatch targets in `test_api_routes.py` and `test_error_propagation.py`

## Acceptance criteria

- [x] `utils/session_cache.py` stores parsed `SessionDict` keyed by absolute path
- [x] Cache invalidated when `os.path.getmtime()` changes
- [x] Configurable max size (default 200) with LRU eviction
- [x] `api/sessions.py` — `get_session` + `get_session_stats` share one cached parse
- [x] `api/search.py` uses cache
- [x] `api/projects.py` and `api/export_api.py` use cache
- [x] Repeated-access benchmark in `tests/benchmarks/`
- [x] `test_parse_memory.py` still passes
- [x] Identical JSON responses; all tests green

## Test plan

- [x] `pytest -q` — 382 passed
- [x] `pytest tests/benchmarks/test_parse_memory.py -q`
- [x] `pytest tests/benchmarks/test_cache_bench.py --benchmark-only`
- [x] `mypy -p api -p utils -p models`
- [x] `ruff check .`

## Out of scope

- Benchmark regression gate (Wednesday PR 2 — #6)
- `quick_session_info` lightweight cache
- Bulk export path (`utils/export_engine`) — still calls `parse_session` directly

## Notes

Cache benchmark (local, medium corpus): warm hit ~11µs vs cold parse ~1.45ms (~135× faster).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a thread-safe in-memory session cache with mtime-based change detection, LRU eviction (200-entry default), and controls to clear or resize the cache.

* **Performance Improvements**
  * Session details, stats, project session listings, and search now reuse cached session data when unchanged.

* **Bug Fixes**
  * Strengthened error-handling coverage to prevent exception details or internal strings from leaking on failures.

* **Tests**
  * Expanded cache tests (cold/warm, invalidation, path normalization, eviction, validation, OSError resilience) and added cache benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->