### PR TITLE
claude-code-chat-browser: Cut v0.1.0 release tag + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-18
+
 ### Added
 
-- `__version__` in `app.py` for release tracking (`0.1.0.dev0` until the first `v0.1.0` git tag)
+- `__version__` in `app.py` for release tracking (`0.1.0` — first tagged release)
 - Startup guard refusing `--debug` with a non-loopback `--host` (including bracketed IPv6 loopback such as `[::1]`)
 - [Deprecation policy](docs/deprecation-policy.md) for API and JSON field changes
 - API field **stability** tables in `docs/api-reference.md` (stable / experimental / deprecated)
+- Vitest coverage for router, page modules, and tool renderers (`static/js/`)
+- `Content-Security-Policy` header on all Flask responses; theme-init IIFE externalized to `static/js/theme-init.js`
+- `RoleLiteral` narrowing for `MessageDict.role` with unknown-role fallback
+- Mtime-invalidated LRU `session_cache` shared across session, stats, search, projects, and export APIs
+- CI benchmark regression gate with populated `benchmarks/baselines.json` (fails on >20% mean regression)
 
 ### Changed
 
 - README notes that the server enforces the debug + host safety rule at startup
+- `utils/jsonl_parser.__all__` trimmed to public API symbols only (`parse_session`, `quick_session_info`)
 
 ### Removed
 
-- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60; removed before first `v0.1.0` tag per [deprecation policy](docs/deprecation-policy.md) bundled SPA path; SPA updated in same `[Unreleased]` cut)
+- `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60; removed before `v0.1.0` per [deprecation policy](docs/deprecation-policy.md) bundled SPA path; SPA updated in same release cut)
 
-[Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/f70505982d435f8b1f754cb18c0c9f65609f11b4...HEAD
+[Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/cppalliance/claude-code-chat-browser/commits/v0.1.0

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 """Flask app that serves the web GUI for browsing sessions."""
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"
 
 import argparse
 import sys

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -37,7 +37,7 @@ For fields **only read by the bundled SPA** (no external integrators on a tagged
 
 | Field | Endpoint | Status | Replacement | Notes |
 |-------|----------|--------|-------------|-------|
-| `export_count` | `GET /api/export/state` | removed | `last_export_session_count` | Deprecated in PR #60 (`[Unreleased]`); removed in bundled SPA+API PR before first `v0.1.0` tag |
+| `export_count` | `GET /api/export/state` | removed | `last_export_session_count` | Deprecated in PR #60 (`[Unreleased]`); removed in `[0.1.0]` |
 
 ## Versioning
 


### PR DESCRIPTION
Closes #84 

## Summary
- Bump `app.__version__` from `0.1.0.dev0` to `0.1.0`
- Restructure CHANGELOG: `[0.1.0] - 2026-06-18` + fresh empty `[Unreleased]` with tag-based compare links
- Update deprecation-policy example table to reference the real `[0.1.0]` release
- `pyproject.toml`: N/A — no `[project]` table / build backend configured

## Post-merge steps (release maintainer)
1. `git checkout master && git pull`
2. `git tag -a v0.1.0 -m "v0.1.0" && git push origin v0.1.0`
3. `gh release create v0.1.0 --title "v0.1.0" --notes-file release-notes-0.1.0.md` (extract `[0.1.0]` CHANGELOG section)
4. Follow-up commit on `master`: bump `__version__` to `"0.2.0.dev0"`

## Test plan
- [x] pytest, mypy, ruff, npm test green locally
- [ ] CI green on PR
- [ ] Tag + GitHub Release after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup safety enforcement for debug mode with non-loopback hosts.
  * Implemented Content-Security-Policy security headers.
  * Added shared session caching with mtime invalidation.
  * Added CI benchmark regression testing.

* **Documentation**
  * Documented API deprecation policy with stability guidelines and removal timeline.

* **Chores**
  * Released version 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->