### PR TITLE
test: enforce tool_dispatch predicate ordering invariants

### DIFF
--- a/tests/test_tool_dispatch_ordering.py
+++ b/tests/test_tool_dispatch_ordering.py
@@ -1,0 +1,76 @@
+"""Structural ordering invariants for ``_TOOL_RESULT_DISPATCH``.
+
+First matching predicate wins; misordering silently misclassifies tool results.
+Invariants are declared as ``(before, after, reason)`` triples — add a row to
+``ORDERING_INVARIANTS`` when inserting a predicate that must sit above another.
+"""
+
+from collections.abc import Callable
+
+import pytest
+
+from models.tool_results import (
+    is_file_write_tool_result,
+    is_plan_tool_result,
+    is_task_async_tool_result,
+    is_task_completed_tool_result,
+    is_task_message_tool_result,
+    is_task_retrieval_tool_result,
+)
+from utils.tool_dispatch import _TOOL_RESULT_DISPATCH
+
+Predicate = Callable[..., bool]
+
+ORDERING_INVARIANTS: list[tuple[Predicate, Predicate, str]] = [
+    (
+        is_plan_tool_result,
+        is_file_write_tool_result,
+        "plan blobs may carry filePath + content; plan must win before file_write",
+    ),
+    (
+        is_task_message_tool_result,
+        is_task_retrieval_tool_result,
+        "task_message is broad (task_id or message); must precede narrower task_retrieval",
+    ),
+    (
+        is_task_message_tool_result,
+        is_task_completed_tool_result,
+        "task_message is broad (task_id or message); must precede narrower task_completed",
+    ),
+    (
+        is_task_message_tool_result,
+        is_task_async_tool_result,
+        "task_message is broad (task_id or message); must precede narrower task_async",
+    ),
+]
+
+
+def _predicate_index(predicate: Predicate) -> int:
+    for i, (pred, _) in enumerate(_TOOL_RESULT_DISPATCH):
+        if pred is predicate:
+            return i
+    raise ValueError(f"predicate {predicate.__name__} not found in _TOOL_RESULT_DISPATCH")
+
+
+@pytest.mark.parametrize(
+    "before,after,reason",
+    ORDERING_INVARIANTS,
+    ids=[
+        "plan_before_file_write",
+        "task_message_before_task_retrieval",
+        "task_message_before_task_completed",
+        "task_message_before_task_async",
+    ],
+)
+def test_tool_dispatch_ordering_invariant(
+    before: Predicate,
+    after: Predicate,
+    reason: str,
+) -> None:
+    before_idx = _predicate_index(before)
+    after_idx = _predicate_index(after)
+    assert before_idx < after_idx, (
+        f"_TOOL_RESULT_DISPATCH ordering violation: "
+        f"{before.__name__} (index {before_idx}) must precede "
+        f"{after.__name__} (index {after_idx}). Reason: {reason}"
+    )

--- a/tests/test_tool_dispatch_ordering.py
+++ b/tests/test_tool_dispatch_ordering.py
@@ -46,7 +46,9 @@ ORDERING_INVARIANTS: list[tuple[Predicate, Predicate, str]] = [
 
 
 def _predicate_index(predicate: Predicate) -> int:
-    for i, (pred, _) in enumerate(_TOOL_RESULT_DISPATCH):
+    for i, entry in enumerate(_TOOL_RESULT_DISPATCH):
+        pred = entry[0]
+        # Identity match: dispatch table must store bare function refs (not wrappers).
         if pred is predicate:
             return i
     raise ValueError(f"predicate {predicate.__name__} not found in _TOOL_RESULT_DISPATCH")

--- a/utils/tool_dispatch.py
+++ b/utils/tool_dispatch.py
@@ -10,6 +10,10 @@ Notably ``task_message`` is broad (``task_id`` or ``message``) and sits before
 To add a shape: append ``(pred, build)`` at the end, or insert only after
 verifying predicates above would not steal intended matches.
 
+Ordering invariants are enforced structurally by
+``tests/test_tool_dispatch_ordering.py`` — add a ``(before, after, reason)``
+tuple there when a new predicate must sit above another.
+
 Predicates live in ``models.tool_results`` (single source of truth for narrowing).
 """
 


### PR DESCRIPTION
Closes #95 

## Summary

- Add `tests/test_tool_dispatch_ordering.py` with declarative `(before, after, reason)` ordering invariants for `_TOOL_RESULT_DISPATCH`
- Assert `is_plan` before `is_file_write` and `is_task_message` before narrower task predicates (`is_task_retrieval`, `is_task_completed`, `is_task_async`)
- Cross-reference the test from `utils/tool_dispatch.py` module docstring

## Test plan

- [x] `pytest tests/test_tool_dispatch_ordering.py -v` — 4 passed
- [x] `pytest` — 413 passed, 13 skipped
- [ ] Misorder a predicate locally — confirm test fails with constraint message, then revert

Sprint item #2 (Thursday, 3 pt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance on maintaining consistent tool-result predicate ordering when extending tool-result dispatch behavior.

* **Tests**
  * Added coverage that verifies declared tool-result dispatch ordering invariants and reports detailed failures if the expected “before”/“after” sequence changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->