### PR TITLE
docs: add 0.2.0 changelog for lock-order and parity work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-30
+
+### Added
+
+- `docs/architecture.md` (#138): FTS5 search-index lock order, threading model, and forbidden nesting rules
+- `tests/test_search_index_concurrency.py` (#139): concurrent rebuild and query, background refresh under load, lock-order assertions, `index_locked` live-scan fallback
+- Dual-path parity oracles (#140): `tests/test_dual_path_parity_oracle.py` and `static/js/render/tool_result/dual_path_parity_oracle.test.js` run the same XSS payload through Python (`utils/md_exporter.py`, `utils/tool_dispatch.py`) and JS `renderToolResult`; malformed-input cases for truncated JSONL, broken parent UUIDs, and NUL bytes
+
 ## [0.1.0] - 2026-06-18
 
 ### Added
@@ -29,5 +37,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `export_count` on `GET /api/export/state` — use `last_export_session_count` (deprecated in PR #60; removed before `v0.1.0` per [deprecation policy](docs/deprecation-policy.md) bundled SPA path; SPA updated in same release cut)
 
-[Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/cppalliance/claude-code-chat-browser/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/cppalliance/claude-code-chat-browser/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cppalliance/claude-code-chat-browser/commits/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `docs/architecture.md` (#138): FTS5 search-index lock order, threading model, and forbidden nesting rules
-- `tests/test_search_index_concurrency.py` (#139): concurrent rebuild and query, background refresh under load, lock-order assertions, `index_locked` live-scan fallback
-- Dual-path parity oracles (#140): `tests/test_dual_path_parity_oracle.py` and `static/js/render/tool_result/dual_path_parity_oracle.test.js` run the same XSS payload through Python (`utils/md_exporter.py`, `utils/tool_dispatch.py`) and JS `renderToolResult`; malformed-input cases for truncated JSONL, broken parent UUIDs, and NUL bytes
+- `KNOWN_TOOL_TYPES` registry in `utils/tool_dispatch.py`; sync test keeps dispatch, file activity, Markdown export, and frontend renderers in step (#104)
+- `static/tool_types.json` generated from the registry and loaded at SPA boot; warns in the console when renderers drift; unknown tools show their type name and JSON payload (#105)
+- `GET /api/schema-report` and an amber banner on the session list when upstream JSONL fields appear or go missing (#108)
+- Disk summary cache at `~/.claude-code-chat-browser/session_summary_cache.sqlite` plus a display-name cache so project and session lists load faster after restart (#111)
+- FTS5 search index in `utils/search_index.py` with background rebuild; `/api/search` hits the index first and falls back to live scan; default window is 30 days (`all_history`, `since_days` for wider ranges) (#120)
+- `/api/search` returns proper error codes for empty queries, overlong queries, bad `since_days`, and locked indexes; search page gets an all-history checkbox, a 50-result cap warning, snippet highlighting, and separate empty vs error UI (#121)
+- Lock order and threading model for the search index in `docs/architecture.md` (#138)
+- `tests/test_search_index_concurrency.py` for rebuild/query concurrency and lock-order checks (#139)
+- Python and Vitest parity oracles in `tests/test_dual_path_parity_oracle.py` and `static/js/render/tool_result/dual_path_parity_oracle.test.js` (#140)
+
+### Changed
+
+- Session, stats, and export routes share `api/_session_handlers.py` and one `SESSION_LOAD_ERRORS` tuple (#125)
+- Tool result dispatch picks winners by explicit priority instead of tuple order (`plan` over `file_write`, `task_message` over narrower task shapes) (#127)
+- CLI bulk export prints the same `ErrorCode` values and messages as the HTTP API (#134)
+
+### Fixed
+
+- YAML frontmatter in Markdown export now quotes values that contain colons, `#`, tabs, newlines, or boolean literals; `models_used` and `service_tiers` export as sequences (#107)
+- `SEARCH_INDEX_UNAVAILABLE` (503) when the FTS index is locked and live scan also fails (#122)
 
 ## [0.1.0] - 2026-06-18
 


### PR DESCRIPTION
Closes #141 
Docs-only. Adds a [0.2.0] section to CHANGELOG.md for the Week 30 work in #138, #139, and #140: the search-index lock-order doc, the concurrency suite, and the Python/JS parity oracles. Clears [Unreleased] and updates the footer compare links. No version bump here; that lands in the release PR.

git diff --stat should show only CHANGELOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.2.0.
  * Documented search-index locking/threading and forbidden nesting rules.
* **New Features**
  * Added schema-report API with user-facing messaging when upstream JSONL fields change.
  * Improved search with FTS5 index-first behavior and background rebuilds.
* **Changed**
  * Improved tool-type syncing at SPA startup and added drift warnings.
  * Consolidated session/stats/export handling and aligned export error codes with the HTTP API.
* **Bug Fixes / Improvements**
  * Improved error handling (including locked-index/live-scan behavior) and fixed YAML frontmatter quoting.  
  * Added/expanded concurrent search and Python/JavaScript parity tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->