### PR TITLE
chore(release): bump app.py to 0.2.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 """Flask app that serves the web GUI for browsing sessions."""
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0"
 
 import argparse
 import logging

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -43,7 +43,7 @@ For fields **only read by the bundled SPA** (no external integrators on a tagged
 
 ## Versioning
 
-Release versions follow `MAJOR.MINOR.PATCH` in `app.__version__` and [CHANGELOG](../CHANGELOG.md). [`v0.1.0`](https://github.com/cppalliance/claude-code-chat-browser/releases/tag/v0.1.0) is the first shipped git tag; `main` carries a `.dev0` suffix while developing the next release (currently `0.2.0.dev0`). The CHANGELOG `[Unreleased]` section is the source of truth for changes not yet tagged.
+Release versions follow `MAJOR.MINOR.PATCH` in `app.__version__` and [CHANGELOG](../CHANGELOG.md). Shipped tags include [`v0.1.0`](https://github.com/cppalliance/claude-code-chat-browser/releases/tag/v0.1.0) and [`v0.2.0`](https://github.com/cppalliance/claude-code-chat-browser/releases/tag/v0.2.0). Between releases, `main` may carry a `.dev0` suffix in `app.__version__` while developing the next version. The CHANGELOG `[Unreleased]` section is the source of truth for changes not yet tagged.
 
 | Bump | Pre-1.0 meaning |
 |------|-----------------|


### PR DESCRIPTION
CLoses #142 

Release cut for v0.2.0. Stacks on #144, which already landed the [0.2.0] changelog on master.

This PR bumps app.py __version__ from 0.2.0.dev0 to 0.2.0 and updates docs/deprecation-policy.md so it no longer pins the old dev suffix. git grep 0.2.0.dev0 should return nothing after merge.

There is no wheel or npm publish step. 

After this merges, tag v0.2.0 on the release commit and create the GitHub Release with notes copied from the [0.2.0] section in CHANGELOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 0.2.0.

* **Documentation**
  * Updated versioning guidance with the v0.2.0 release and clarified development-version suffix conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->